### PR TITLE
Anime Card Fixes

### DIFF
--- a/script/c100000590.lua
+++ b/script/c100000590.lua
@@ -46,6 +46,7 @@ function c100000590.sfilter(c)
 	return c:IsSSetable() and (c:IsCode(100000591) or c:IsCode(100000592) or c:IsCode(100000593) or c:IsCode(100000594) or c:IsCode(100000595))
 end
 function c100000590.activate(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
 	local g=Duel.GetMatchingGroup(c100000590.desfilter,tp,LOCATION_ONFIELD,0,e:GetHandler())
 	Duel.Destroy(g,REASON_EFFECT)
 	local ft=Duel.GetLocationCount(tp,LOCATION_SZONE)
@@ -91,6 +92,7 @@ function c100000590.setfilter(c)
 	return c:IsFaceup() and c:IsType(TYPE_TRAP)
 end
 function c100000590.setop(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
 	local g=Duel.GetMatchingGroup(c100000590.setfilter,tp,LOCATION_ONFIELD,0,nil)
 	local tc=g:GetFirst()
 	while tc do

--- a/script/c511000061.lua
+++ b/script/c511000061.lua
@@ -2,7 +2,8 @@
 function c511000061.initial_effect(c)
 	--Return
 	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_QUICK_O)
+	--e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetType(EFFECT_TYPE_ACTIVATE)
 	e2:SetCode(EVENT_FREE_CHAIN)
 	e2:SetRange(LOCATION_GRAVE)
 	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
@@ -18,7 +19,7 @@ function c511000061.rtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local c=e:GetHandler()
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c511000061.rfilter(chkc) end
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0 and Duel.IsExistingTarget(c511000061.rfilter,tp,LOCATION_MZONE,0,1,nil) end
-	e:SetType(EFFECT_TYPE_ACTIVATE)
+	--e:SetType(EFFECT_TYPE_ACTIVATE)
 	Duel.MoveToField(c,tp,tp,LOCATION_SZONE,POS_FACEUP,true)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
 	Duel.SelectTarget(tp,c511000061.rfilter,tp,LOCATION_MZONE,0,1,1,nil)

--- a/script/c511000990.lua
+++ b/script/c511000990.lua
@@ -20,19 +20,76 @@ function c511000990.initial_effect(c)
 	e2:SetProperty(EFFECT_FLAG_IGNORE_RANGE+EFFECT_FLAG_SET_AVAILABLE+EFFECT_FLAG_CANNOT_DISABLE)
 	e2:SetValue(TYPE_NORMAL)
 	c:RegisterEffect(e2)
+	local f=Card.IsCanBeFusionMaterial
+	Card.IsCanBeFusionMaterial=function(c,fc,ismon)
+		if (c:GetSequence()==6 or c:GetSequence()==7) and c:IsLocation(LOCATION_SZONE) then
+			return f(c,fc,true)
+		end
+		if c:IsCode(80604091) then return f(c,fc,true) end
+		return f(c,fc,ismon)
+	end
+	local fchk=Card.CheckFusionMaterial
+	Card.CheckFusionMaterial=function(c,m,mc,chkf)
+		if c:IsCode(511000990) then
+			local mg1=Group.CreateGroup()
+			local mg2=Group.CreateGroup()
+			if m:IsExists(c511000990.sameplayerchk,1,nil,c:GetControler()) then
+				mg1=Duel.GetMatchingGroup(Card.IsCanBeFusionMaterial,c:GetControler(),LOCATION_SZONE,0,nil,c)
+				m:Merge(mg1)
+			end
+			if m:IsExists(c511000990.sameplayerchk,1,nil,1-c:GetControler()) then
+				mg1=Duel.GetMatchingGroup(Card.IsCanBeFusionMaterial,c:GetControler(),LOCATION_SZONE,0,nil,c)
+				mg2=Duel.GetMatchingGroup(c511000990.mat2,c:GetControler(),0,LOCATION_SZONE,nil,c)
+				m:Merge(mg1)
+				m:Merge(mg2)
+			end
+			if fchk(c,m,mc,chkf) then
+				m:Sub(mg1)
+				m:Sub(mg2)
+				return true
+			end
+			m:Sub(mg1)
+			m:Sub(mg2)
+		end
+		return fchk(c,m,mc,chkf)
+	end
+	local fsel=Duel.SelectFusionMaterial
+	Duel.SelectFusionMaterial=function(tp,c,mg,mc,chkf)
+		if c:IsCode(511000990) then
+			if mg:IsExists(c511000990.sameplayerchk,1,nil,tp) then
+				local mg1=Duel.GetMatchingGroup(Card.IsCanBeFusionMaterial,tp,LOCATION_SZONE,0,nil)
+				mg:Merge(mg1)
+			end
+			if mg:IsExists(c511000990.sameplayerchk,1,nil,1-tp) then
+				local mg1=Duel.GetMatchingGroup(Card.IsCanBeFusionMaterial,tp,LOCATION_SZONE,0,nil)
+				local mg2=Duel.GetMatchingGroup(c511000990.mat2,tp,0,LOCATION_SZONE,nil)
+				mg:Merge(mg1)
+				mg:Merge(mg2)
+			end
+		end
+		if Duel.IsPlayerAffectedByEffect(1-tp,5000) and Duel.SelectYesNo(1-tp,aux.Stringid(4002,8)) then  
+ 			Duel.ConfirmCards(1-tp,g)
+ 			local label=0
+ 			if mg:IsExists(Card.IsLocation,1,nil,LOCATION_HAND) or (mc and mc:IsLocation(LOCATION_HAND)) then label=label+1 end
+ 			if mg:IsExists(Card.IsLocation,1,nil,LOCATION_DECK) or (mc and mc:IsLocation(LOCATION_DECK)) then label=label+2 end
+ 			Duel.RegisterFlagEffect(1-tp,511004008+label,0,0,1)
+ 			return fsel(1-tp,c,mg,mc,chkf)
+ 		end
+		return fsel(tp,c,mg,mc,chkf)
+	end
+end
+function c511000990.sameplayerchk(c,tp)
+	return c:IsLocation(LOCATION_MZONE) and c:IsControler(tp)
+end
+function c511000990.mat2(c)
+	return c:IsCanBeFusionMaterial() and c:IsFaceup()
 end
 c511000990.illegal=true
 function c511000990.FConditionCheckF(c,chkf)
 	return c:IsLocation(LOCATION_MZONE) and c:IsControler(chkf)
 end
-function Auxiliary.FConditionFilter12(c,code,sub,fc)
-	return c:IsFusionCode(code) or (sub and c:CheckFusionSubstitute(fc))
-end
-function Auxiliary.FConditionFilter21(c,code1,code2)
-	return c:IsFusionCode(code1,code2)
-end
-function Auxiliary.FConditionFilter22(c,code1,code2,sub,fc)
-	return c:IsFusionCode(code1,code2) or (sub and c:CheckFusionSubstitute(fc))
+function Auxiliary.FConditionFilter21(c,code1,code2,sub)
+	return c:IsFusionCode(code1,code2) or (sub and c:IsHasEffect(511002961))
 end
 function c511000990.fscon(e,g,gc,chkfnf)
 	if g==nil then return true end
@@ -49,18 +106,14 @@ function c511000990.fscon(e,g,gc,chkfnf)
 		if chkf~=PLAYER_NONE and not aux.FConditionCheckF(gc,chkf) then
 			mg=mg:Filter(c511000990.FConditionCheckF,nil,chkf)
 		end
-		local sg=Duel.GetMatchingGroup(Card.IsCode,e:GetHandlerPlayer(),LOCATION_ONFIELD+LOCATION_HAND,0,nil,80604091)
 		if b1+b2+bw>1 or bwx==1 then
-			if mg:IsExists(aux.FConditionFilter22,1,nil,78010363,80604091,true,e:GetHandler()) then return true
-			else return sg:GetCount()>0 end
+			return mg:IsExists(aux.FConditionFilter22,1,nil,78010363,80604091,true,e:GetHandler())
 		elseif b1==1 then
-			if mg:IsExists(aux.FConditionFilter12,1,nil,80604091,true,e:GetHandler()) then return true
-			else return sg:GetCount()>0 end
+			return mg:IsExists(aux.FConditionFilter12,1,nil,80604091,true,e:GetHandler())
 		elseif b2==1 then
 			return mg:IsExists(aux.FConditionFilter12,1,nil,78010363,true,e:GetHandler())
 		else
-			if mg:IsExists(aux.FConditionFilter21,1,nil,78010363,80604091) then return true
-			else return sg:GetCount()>0 end
+			return mg:IsExists(aux.FConditionFilter21,1,nil,78010363,80604091)
 		end
 	end
 	local b1=0 local b2=0 local bw=0 local bwxct=0
@@ -79,11 +132,7 @@ function c511000990.fscon(e,g,gc,chkfnf)
 		end
 		tc=mg:GetNext()
 	end
-	if not fs then return false end
-	if ct>1 and b1+b2+bw+bwxct>1 then return true end
-	if b2==1 then return false end
-	local sg=Duel.GetMatchingGroup(Card.IsCode,e:GetHandlerPlayer(),LOCATION_ONFIELD+LOCATION_HAND,0,nil,80604091)
-	return ct>0 and b1+bw+bwxct>0 and sg:GetCount()>0
+	return fs and ct>1 and b1+b2+bw+bwxct>1
 end
 function c511000990.fsop(e,tp,eg,ep,ev,re,r,rp,gc,chkfnf)
 	local chkf=bit.band(chkfnf,0xff)
@@ -95,10 +144,7 @@ function c511000990.fsop(e,tp,eg,ep,ev,re,r,rp,gc,chkfnf)
 			g=g:Filter(c511000990.FConditionCheckF,nil,chkf)
 		end
 	else
-		local sg=g:Filter(Auxiliary.FConditionFilter22,nil,code1,code2,true,e:GetHandler())
-		local sg2=Duel.GetMatchingGroup(Card.IsCode,tp,LOCATION_ONFIELD+LOCATION_HAND,0,nil,80604091)
-		g:Merge(sg2)
-		sg:Merge(sg2)
+		local sg=g:Filter(Auxiliary.FConditionFilter22,nil,78010363,80604091,true,e:GetHandler())
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
 		if chkf~=PLAYER_NONE then g1=sg:FilterSelect(tp,c511000990.FConditionCheckF,1,1,nil,chkf)
 		else g1=sg:Select(tp,1,1,nil) end

--- a/script/c511001586.lua
+++ b/script/c511001586.lua
@@ -10,20 +10,21 @@ function c511001586.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c511001586.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=Duel.GetTurnPlayer()
+	return Duel.GetAttacker():IsControler(1-tp)
 end
 function c511001586.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local tg=Duel.GetAttackTarget()
-	if chk==0 then return tg:IsOnField() and tg:GetAttack()>0 and tg:IsFaceup() and Duel.IsPlayerCanDraw(tp,1) end
+	if chk==0 then return tg and tg:IsOnField() and tg:GetAttack()>0 and tg:IsFaceup() and Duel.IsPlayerCanDraw(tp,1) end
 end
 function c511001586.activate(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetAttackTarget() then
+	local d=Duel.GetAttackTarget()
+	if d and d:IsRelateToBattle() then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetReset(RESET_EVENT+0xfe0000)
 		e1:SetCode(EFFECT_SET_ATTACK_FINAL)
 		e1:SetValue(0)
-		Duel.GetAttackTarget():RegisterEffect(e1)
+		d:RegisterEffect(e1)
 		local e2=Effect.CreateEffect(e:GetHandler())
 		e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 		e2:SetCode(EVENT_BATTLED)

--- a/script/c511001891.lua
+++ b/script/c511001891.lua
@@ -53,6 +53,7 @@ function c511001891.operation(e,tp,eg,ep,ev,re,r,rp)
 			or not Duel.IsPlayerCanSpecialSummonMonster(tp,511001892,0,0x4011,tc:GetAttack(),tc:GetDefense(),
 			tc:GetLevel(),tc:GetRace(),tc:GetAttribute()) then return end
 		local token=Duel.CreateToken(tp,511001892)
+		token:CopyEffect(tc:GetOriginalCode(),RESET_EVENT+0xfe0000,1)
 		Duel.SpecialSummonStep(token,0,tp,tp,false,false,POS_FACEUP)
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
@@ -76,7 +77,14 @@ function c511001891.operation(e,tp,eg,ep,ev,re,r,rp)
 		e5:SetCode(EFFECT_CHANGE_ATTRIBUTE)
 		e5:SetValue(tc:GetAttribute())
 		token:RegisterEffect(e5)
-		token:CopyEffect(tc:GetOriginalCode(),RESET_EVENT+0x1fe0000,1)
+		if tc:IsType(TYPE_EFFECT) and not token:IsType(TYPE_EFFECT) then
+			local e6=Effect.CreateEffect(c)
+			e6:SetType(EFFECT_TYPE_SINGLE)
+			e6:SetCode(EFFECT_ADD_TYPE)
+			e6:SetValue(TYPE_EFFECT)
+			e6:SetReset(RESET_EVENT+0x1fe0000)
+			token:RegisterEffect(e6)
+		end
 		Duel.SpecialSummonComplete()
 		c:SetCardTarget(token)
 	end

--- a/script/c511002002.lua
+++ b/script/c511002002.lua
@@ -1,31 +1,35 @@
---Performapal Barrier Balloon Baku
+--EMバリアバルーンバク
 function c511002002.initial_effect(c)
-	--no damage
+	--
 	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(511001684,0))
-	e1:SetType(EFFECT_TYPE_QUICK_O+EFFECT_TYPE_FIELD)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetRange(LOCATION_HAND)
-	e1:SetCode(EVENT_PRE_DAMAGE_CALCULATE)
-	e1:SetCondition(c511002002.con)
-	e1:SetCost(c511002002.cost)
-	e1:SetOperation(c511002002.op)
+	e1:SetHintTiming(TIMING_DAMAGE_STEP)
+	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DAMAGE_CAL)
+	e1:SetCost(c511002002.dmcost)
+	e1:SetOperation(c511002002.dmop)
 	c:RegisterEffect(e1)
 end
-function c511002002.con(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetBattleDamage(tp)>0
-end
-function c511002002.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+function c511002002.dmcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToGraveAsCost() end
 	Duel.SendtoGrave(e:GetHandler(),REASON_COST)
 end
-function c511002002.op(e,tp,eg,ep,ev,re,r,rp)
-	local e1=Effect.CreateEffect(e:GetHandler())
-	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-	e1:SetCode(EVENT_PRE_BATTLE_DAMAGE)
-	e1:SetOperation(c511002002.damop)
-	e1:SetReset(RESET_PHASE+PHASE_DAMAGE)
-	Duel.RegisterEffect(e1,tp)
+function c511002002.dmop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.CheckEvent(EVENT_PRE_BATTLE_DAMAGE) then
+		Duel.ChangeBattleDamage(tp,0)
+		Duel.ChangeBattleDamage(1-tp,0)
+	else
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e1:SetCode(EVENT_PRE_BATTLE_DAMAGE)
+		e1:SetCountLimit(1)
+		e1:SetOperation(c511002002.nodamop)
+		e1:SetReset(RESET_PHASE+PHASE_END)
+		Duel.RegisterEffect(e1,tp)
+	end
 end
-function c511002002.damop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.ChangeBattleDamage(ep,0)
+function c511002002.nodamop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.ChangeBattleDamage(tp,0)
+	Duel.ChangeBattleDamage(1-tp,0)
 end

--- a/script/c511002034.lua
+++ b/script/c511002034.lua
@@ -9,7 +9,7 @@ function c511002034.initial_effect(c)
 	e1:SetCategory(CATEGORY_DISABLE+CATEGORY_DESTROY)
 	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_QUICK_O)
 	e1:SetCode(EVENT_CHAINING)
-	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DAMAGE_CAL)
+	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DAMAGE_CAL+EFFECT_FLAG_CARD_TARGET)
 	e1:SetRange(LOCATION_MZONE)
 	e1:SetCondition(c511002034.condition)
 	e1:SetTarget(c511002034.target)
@@ -38,16 +38,19 @@ function c511002034.condition2(e,tp,eg,ep,ev,re,r,rp)
 		and not c:IsStatus(STATUS_BATTLE_DESTROYED) and Duel.IsChainDisablable(ev)
 end
 function c511002034.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
+	local rc=re:GetHandler()
+	if chk==0 then return rc and rc:IsCanBeEffectTarget(e) end
+	Duel.SetTargetCard(rc)
 	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
-	if re:GetHandler():IsDestructable() and re:GetHandler():IsRelateToEffect(re) then
+	if rc:IsDestructable() and rc:IsRelateToEffect(re) then
 		Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,1,0,0)
 	end
 end
 function c511002034.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	Duel.NegateEffect(ev)
 	local rc=re:GetHandler()
+	if not rc or not rc:IsRelateToEffect(e) then return end
+	Duel.NegateEffect(ev)
 	if rc:IsRelateToEffect(re) and Duel.Destroy(rc,REASON_EFFECT)>0 then
 		if c:IsRelateToEffect(e) and c:IsFaceup() then
 			local atk=rc:GetTextAttack()

--- a/script/c511002653.lua
+++ b/script/c511002653.lua
@@ -29,7 +29,15 @@ function c511002653.activate(e,tp,eg,ep,ev,re,r,rp)
 		local tc2=g:GetFirst()
 		if tc2 then
 			Duel.HintSelection(g)
-			tc:CopyEffect(tc2:GetOriginalCode(),RESET_EVENT+0x1fe0000,1)
+			tc:CopyEffect(tc2:GetOriginalCode(),RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,1)
+			if not tc:IsType(TYPE_EFFECT) then
+				local e1=Effect.CreateEffect(e:GetHandler())
+				e1:SetType(EFFECT_TYPE_SINGLE)
+				e1:SetCode(EFFECT_ADD_TYPE)
+				e1:SetValue(TYPE_EFFECT)
+				e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+				tc:RegisterEffect(e1)
+			end
 		end
 	end
 end

--- a/script/c511002730.lua
+++ b/script/c511002730.lua
@@ -15,9 +15,11 @@ function c511002730.initial_effect(c)
 		ge1:SetCode(EFFECT_CANNOT_LOSE_LP)
 		ge1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 		ge1:SetTargetRange(1,0)
+		ge1:SetLabel(0)
 		ge1:SetCondition(c511002730.con2)
 		Duel.RegisterEffect(ge1,0)
 		local ge2=ge1:Clone()
+		ge2:SetLabel(1)
 		Duel.RegisterEffect(ge2,1)
 		local ge3=Effect.CreateEffect(c)
 		ge3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
@@ -26,8 +28,8 @@ function c511002730.initial_effect(c)
 		Duel.RegisterEffect(ge3,0)
 	end
 end
-function c511002730.con2(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetFlagEffect(tp,511002521)>0
+function c511002730.con2(e)
+	return Duel.GetFlagEffect(e:GetLabel(),511002521)>0
 end
 function c511002730.op(e,tp,eg,ep,ev,re,r,rp)
 	local ph=Duel.GetCurrentPhase()

--- a/script/c511002808.lua
+++ b/script/c511002808.lua
@@ -2,7 +2,7 @@
 function c511002808.initial_effect(c)
 	--fusion material
 	c:EnableReviveLimit()
-	aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsFusionSetCard,0xf1),aux.FilterBoolFunction(Card.IsRace,RACE_BEAST),true)
+	aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsFusionSetCard,0xf2),aux.FilterBoolFunction(Card.IsRace,RACE_BEAST),true)
 	--damage
 	local e3=Effect.CreateEffect(c)
 	e3:SetCategory(CATEGORY_DAMAGE)

--- a/script/c511002809.lua
+++ b/script/c511002809.lua
@@ -2,7 +2,7 @@
 function c511002809.initial_effect(c)
 	--fusion material
 	c:EnableReviveLimit()
-	aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsFusionSetCard,0xf1),aux.FilterBoolFunction(Card.IsRace,RACE_SPELLCASTER),true)
+	aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsFusionSetCard,0xf2),aux.FilterBoolFunction(Card.IsRace,RACE_SPELLCASTER),true)
 	--multi attack
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)

--- a/script/c511007006.lua
+++ b/script/c511007006.lua
@@ -1,7 +1,8 @@
 --coded by Lyris
 --Flash Fang
+--fixed by MLD
 function c511007006.initial_effect(c)
-	--All "Shark" monsters you currently control gain 500 ATK, until the End Phase.
+	--activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_ATKCHANGE)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
@@ -10,20 +11,24 @@ function c511007006.initial_effect(c)
 	e1:SetOperation(c511007006.activate)
 	c:RegisterEffect(e1)
 end
---"Shark" monsters
+c511007006.collection={
+	[13429800]=true;[34290067]=true;[10532969]=true;[71923655]=true;[32393580]=true;
+	[810000016]=true;[20358953]=true;[37798171]=true;[70101178]=true;[23536866]=true;
+	[7500772]=true;[511001410]=true;[69155991]=true;[37792478]=true;[17201174]=true;
+	[44223284]=true;[70655556]=true;[63193879]=true;[25484449]=true;[810000026]=true;
+	[17643265]=true;[64319467]=true;[810000030]=true;[810000008]=true;[20838380]=true;
+	[87047161]=true;[80727036]=true;[28593363]=true;[50449881]=true;[49221191]=true;
+	[65676461]=true;[440556]=true;[511001273]=true;[31320433]=true;[5014629]=true;
+	[14306092]=true;[84224627]=true;[511001163]=true;[511001169]=true;[511001858]=true;
+}
 function c511007006.filter(c)
-	return c:IsFaceup() and c:IsSetCard(0x321)
+	return c:IsFaceup() and (c:IsSetCard(0x321) or c511007006.collection[c:GetCode()])
 end
 function c511007006.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c511007006.filter,tp,LOCATION_MZONE,0,1,nil) end
-	local g=Duel.GetMatchingGroup(c511007006.filter,tp,LOCATION_MZONE,0,nil)
-	Duel.SetTargetCard(g)
-end
-function c511007006.filter2(c,e)
-	return c:IsFaceup() and c:IsSetCard(0x321) and c:IsRelateToEffect(e) and not c:IsImmuneToEffect(e)
 end
 function c511007006.activate(e,tp,eg,ep,ev,re,r,rp)
-	local sg=Duel.GetMatchingGroup(c511007006.filter2,tp,LOCATION_MZONE,0,nil,e)
+	local sg=Duel.GetMatchingGroup(c511007006.filter,tp,LOCATION_MZONE,0,nil)
 	local c=e:GetHandler()
 	local fid=c:GetFieldID()
 	local tc=sg:GetFirst()
@@ -34,42 +39,37 @@ function c511007006.activate(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
 		e1:SetValue(500)
 		tc:RegisterEffect(e1)
-		tc:RegisterFlagEffect(511007006,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1,fid)
+		tc:RegisterFlagEffect(51107006,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1,fid)
 		local e2=Effect.CreateEffect(c)
 		e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
 		e2:SetCode(EVENT_BATTLE_DAMAGE)
-		e2:SetOperation(c511007006.regcon)
+		e2:SetOperation(c511007006.regop)
 		tc:RegisterEffect(e2)
 		tc=sg:GetNext()
 	end
 	sg:KeepAlive()
-	--At the end of this turn's Battle Phase, if a monster(s) affected by this effect has inflicted battle damage to your opponent by a direct attack: You can destroy all monsters your opponent controls with a lower ATK than the damage inflicted.
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
 	e2:SetCode(EVENT_PHASE+PHASE_BATTLE)
 	e2:SetReset(RESET_PHASE+PHASE_BATTLE)
-	e2:SetRange(0xff)
 	e2:SetCountLimit(1)
 	e2:SetLabel(fid)
 	e2:SetLabelObject(sg)
 	e2:SetCondition(c511007006.descon)
 	e2:SetOperation(c511007006.desop)
-	c:RegisterEffect(e2)
+	Duel.RegisterEffect(e2,tp)
 end
---record opponent's inflicted battle damage
-function c511007006.regcon(e,tp,eg,ep,ev,re,r,rp)
+function c511007006.regop(e,tp,eg,ep,ev,re,r,rp)
 	if ep~=tp and Duel.GetAttackTarget()==nil then
 		local c=e:GetHandler()
-		c:SetFlagEffectLabel(511007006,c:GetFlagEffectLabel(511007006)+ev)
+		c:SetFlagEffectLabel(51107006,c:GetFlagEffectLabel(51107006)+ev)
 	end
 end
---monsters that inflicted battle damage to opponent
 function c511007006.desfilter(c,fid)
-	return c:GetFlagEffectLabel(511007006)-fid>0
+	return c:GetFlagEffectLabel(51107006)-fid>0
 end
---monsters with less ATK than damage inflicted
 function c511007006.desopfilter(c,dam)
-	return c:GetAttack()<dam and c:IsDestructable()
+	return c:GetAttack()<dam
 end
 function c511007006.descon(e,tp,eg,ep,ev,re,r,rp)
 	local g=e:GetLabelObject()
@@ -79,7 +79,7 @@ function c511007006.descon(e,tp,eg,ep,ev,re,r,rp)
 		local dam=0
 		local tc=dg:GetFirst()
 		while tc do
-			dam=dam+(tc:GetFlagEffectLabel(511007006)-fid)
+			dam=dam+(tc:GetFlagEffectLabel(51107006)-fid)
 			tc=dg:GetNext()
 		end
 		return Duel.IsExistingMatchingCard(c511007006.desopfilter,tp,0,LOCATION_MZONE,1,nil,dam)
@@ -94,11 +94,10 @@ function c511007006.desop(e,tp,eg,ep,ev,re,r,rp)
 	local fid=e:GetLabel()
 	local dg=g:Filter(c511007006.desfilter,nil,fid)
 	g:DeleteGroup()
-	--destroy all monsters your opponent controls with a lower ATK than the damage inflicted
 	local dam=0
 	local tc=dg:GetFirst()
 	while tc do
-		dam=dam+(tc:GetFlagEffectLabel(511007006)-fid)
+		dam=dam+(tc:GetFlagEffectLabel(51107006)-fid)
 		tc=dg:GetNext()
 	end
 	local sg=Duel.GetMatchingGroup(c511007006.desopfilter,tp,0,LOCATION_MZONE,nil,dam)

--- a/script/c700000009.lua
+++ b/script/c700000009.lua
@@ -25,16 +25,15 @@ function c700000009.initial_effect(c)
 	e3:SetTarget(c700000009.reptg)
 	c:RegisterEffect(e3)
 end
-
 function c700000009.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local at=Duel.GetAttacker()
-	return at:GetControler()~=tp and Duel.GetAttackTarget()==nil
+	return at:IsControler(1-tp) and Duel.GetAttackTarget()==nil
 end
 function c700000009.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local seq=e:GetHandler():GetSequence()
 	local sc=Duel.GetFieldCard(tp,LOCATION_SZONE,13-seq)
-	if chk==0 then return sc and sc:IsDestructable() end
-	Duel.Destroy(sc,REASON_EFFECT+REASON_COST)
+	if chk==0 then return sc and sc:IsDestructable(e) end
+	Duel.Destroy(sc,REASON_COST)
 end
 function c700000009.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
@@ -48,7 +47,6 @@ function c700000009.spop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)
 	end
 end
-
 function c700000009.repfil(c)
 	return (c:GetSequence()==6 or c:GetSequence()==7) and c:IsDestructable()
 end

--- a/script/c700000011.lua
+++ b/script/c700000011.lua
@@ -1,0 +1,56 @@
+--Scripted by Eerie Code
+--Performapal Bot-Eyes Lizard
+function c700000011.initial_effect(c)
+	--Change name
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1)
+	e1:SetCondition(c700000011.condition)
+	e1:SetTarget(c700000011.target)
+	e1:SetOperation(c700000011.operation)   
+	c:RegisterEffect(e1)
+	if not c700000011.global_check then
+		c700000011.global_check=true
+		local ge1=Effect.CreateEffect(c)
+		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge1:SetCode(EVENT_SUMMON_SUCCESS)
+		ge1:SetLabel(700000011)
+		ge1:SetOperation(aux.sumreg)
+		Duel.RegisterEffect(ge1,0)
+		local ge2=ge1:Clone()
+		ge2:SetCode(EVENT_SPSUMMON_SUCCESS)
+		ge2:SetLabel(700000011)
+		Duel.RegisterEffect(ge2,0)
+	end
+end
+function c700000011.condition(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetFlagEffect(700000011)>0
+end
+function c700000011.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.Hint(HINT_SELECTMSG,tp,0)
+	local ac=0
+	local token
+	repeat
+		ac=Duel.AnnounceCard(tp)
+		token=Duel.CreateToken(tp,ac)
+	until token:IsSetCard(0x99)
+	Duel.SetTargetParam(ac)
+	Duel.SetOperationInfo(0,CATEGORY_ANNOUNCE,nil,0,tp,ANNOUNCE_CARD)
+end
+function c700000011.operation(e,tp,eg,ep,ev,re,r,rp)
+	local ac=Duel.GetChainInfo(0,CHAININFO_TARGET_PARAM)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+		e1:SetRange(LOCATION_MZONE)
+		e1:SetCode(EFFECT_CHANGE_CODE)
+		e1:SetValue(ac)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+	end
+end

--- a/script/c810000018.lua
+++ b/script/c810000018.lua
@@ -4,18 +4,19 @@ function c810000018.initial_effect(c)
 	-- to deck top
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_TODECK)
-	e1:SetType(EFFECT_TYPE_IGNITION+EFFECT_TYPE_QUICK_O)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetRange(LOCATION_GRAVE)
 	e1:SetCondition(c810000018.condition)
 	e1:SetTarget(c810000018.target)
 	e1:SetOperation(c810000018.operation)
 	c:RegisterEffect(e1)
 end
-function c810000018.condition(e)
-	return Duel.GetFieldGroupCount(e:GetHandlerPlayer(),LOCATION_HAND,0)==0
+function c810000018.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetFieldGroupCount(tp,LOCATION_HAND,0)==0 and not e:GetHandler():IsStatus(STATUS_CHAINING)
 end
 function c810000018.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
+	if chk==0 then return e:GetHandler():IsAbleToDeck() end
 	Duel.SetOperationInfo(0,CATEGORY_TODECK,e:GetHandler(),1,0,0)
 end
 function c810000018.operation(e,tp,eg,ep,ev,re,r,rp)

--- a/script/c95000000.lua
+++ b/script/c95000000.lua
@@ -36,6 +36,7 @@ function c95000000.initial_effect(c)
 	e5:SetCode(EFFECT_CANNOT_LOSE_DECK)
 	e5:SetRange(LOCATION_REMOVED)
 	e5:SetTargetRange(1,0)
+	e5:SetCondition(c95000000.deckcon)
 	e5:SetValue(1)
 	c:RegisterEffect(e5)
 	--rearrange
@@ -51,9 +52,13 @@ function c95000000.initial_effect(c)
 	local e7=e6:Clone()
 	e7:SetCode(EVENT_CHAIN_SOLVED)
 	c:RegisterEffect(e7)
-	local e8=e6:Clone()
+	local e8=Effect.CreateEffect(c)
+	e8:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e8:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 	e8:SetCode(EVENT_ADJUST)
-	e8:SetCountLimit(999999)
+	e8:SetRange(LOCATION_REMOVED)
+	e8:SetCondition(c95000000.ordercon)
+	e8:SetOperation(c95000000.orderop)
 	c:RegisterEffect(e8)
 	--cannot banish
 	local e9=Effect.CreateEffect(c)
@@ -167,6 +172,9 @@ function c95000000.thop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.Hint(HINT_CARD,0,95000000)
 		Duel.SendtoHand(g,nil,REASON_RULE)
 	end
+end
+function c95000000.deckcon(e)
+	return Duel.GetTurnPlayer()==e:GetHandlerPlayer() and Duel.GetCurrentPhase()==PHASE_DRAW
 end
 function c95000000.ordercon(e,tp,eg,ep,ev,re,r,rp)
 	local ct=1


### PR DESCRIPTION
Boss Duel - cannot lose Duel fix
Darkness - activation Leave Field Checking
Darkness Outsider unnerf (does not include database fix yet)
Anime Odin, added more filters + negate Equip and Targeting cards
Yasushi the Skull Knight - Fusion Material checking update
Zero Gazer - error removed
Spirit Illusion 'Special Summon copy effect' trigger
Performapal Inflater Tapir Anime update (does not include database yet)
Clear Wing Synchro Dragon Anime targeting check
Barrier Ninjitsu Art of Hazy Transfer - add TYPE_EFFECT on copying.
Hope 1 lose duel prevention update
Anime Rune-Eyes and Brave-Eyes Pendulum Dragon Material update
Performapal Odd-Eyes Light Phoenix Anime Destroy Cost update
Performapal Bot-Eyes Lizard Anime Effect Update (does not include database yet)
Infernity Climber effect update (does not include database yet)
Gjallarhorn activation type change to ACTIVATE
