### PR TITLE
Anime Card Fixes #182

### DIFF
--- a/script/c100000199.lua
+++ b/script/c100000199.lua
@@ -11,20 +11,6 @@ function c100000199.initial_effect(c)
 	e2:SetTarget(c100000199.target)
 	e2:SetOperation(c100000199.activate)
 	c:RegisterEffect(e2)
-	if not c100000199.global_check then
-		c100000199.global_check=true
-		local ge1=Effect.CreateEffect(c)
-		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-		ge1:SetCode(EVENT_DAMAGE_STEP_END)
-		ge1:SetOperation(c100000199.checkop)
-		Duel.RegisterEffect(ge1,0)
-	end
-end
-function c100000199.checkop(e,tp,eg,ep,ev,re,r,rp)
-	local tc=Duel.GetAttacker()
-	if Duel.GetAttackTarget()==nil and tc:GetControler()==Duel.GetTurnPlayer() then
-		tc:RegisterFlagEffect(100000199,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,0)
-	end
 end
 function c100000199.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==tp
@@ -39,11 +25,12 @@ function c100000199.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SendtoGrave(g,REASON_COST+REASON_DISCARD)
 end
 function c100000199.filter(c)
-	return c:GetFlagEffect(100000199)>0 and c:IsAttackBelow(1500)
+	return c:IsDirectAttacked() and c:IsAttackBelow(1500)
 end
 function c100000199.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c100000199.filter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(c100000199.filter,tp,LOCATION_MZONE,0,1,nil) end
+	if chk==0 then return Duel.IsExistingTarget(c100000199.filter,tp,LOCATION_MZONE,0,1,nil) 
+		and Duel.IsPlayerCanDraw(tp,1) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
 	Duel.SelectTarget(tp,c100000199.filter,tp,LOCATION_MZONE,0,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,0)
@@ -52,13 +39,12 @@ end
 function c100000199.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	while Duel.Draw(tp,1,REASON_EFFECT)~=0 and tc and tc:IsFaceup() and tc:IsRelateToEffect(e) do
-		local tc=Duel.GetOperatedGroup():GetFirst()
-		Duel.ConfirmCards(tp,tc)		
-		if tc:IsType(TYPE_MONSTER) then		
-			if Duel.SendtoGrave(tc,REASON_EFFECT)~=0 then	
-				Duel.Damage(1-tp,tg:GetAttack(),REASON_EFFECT)
-				local p=e:GetHandler():GetControler()
-				if Duel.GetLP(1-p)<=0 and Duel.GetFieldGroupCount(p,LOCATION_DECK,0)<=0 then
+		local gc=Duel.GetOperatedGroup():GetFirst()
+		Duel.ConfirmCards(tp,gc)
+		if gc and gc:IsType(TYPE_MONSTER) then		
+			if Duel.SendtoGrave(gc,REASON_EFFECT)~=0 then	
+				Duel.Damage(1-tp,tc:GetAttack(),REASON_EFFECT)
+				if Duel.GetLP(1-tp)<=0 and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)<=0 then
 					return Duel.SetLP(tp,0)
 				end
 			end

--- a/script/c100000704.lua
+++ b/script/c100000704.lua
@@ -2,12 +2,10 @@
 function c100000704.initial_effect(c)
 	--dishand
 	local e2=Effect.CreateEffect(c)
-	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 	e2:SetCategory(CATEGORY_TODECK+CATEGORY_SPECIAL_SUMMON)
 	e2:SetType(EFFECT_TYPE_IGNITION)
 	e2:SetRange(LOCATION_MZONE)
-	e2:SetCountLimit(1)
-    e2:SetCost(c100000704.spcost)
+	e2:SetCost(c100000704.spcost)
 	e2:SetTarget(c100000704.target)
 	e2:SetOperation(c100000704.operation)
 	c:RegisterEffect(e2)
@@ -18,27 +16,21 @@ function c100000704.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c100000704.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return Duel.GetFieldGroupCount(tp,0,LOCATION_DECK)>0 and Duel.IsPlayerCanSpecialSummon(tp) 
-		and e:GetHandler():IsAbleToDeck() and Duel.GetLocationCount(tp,LOCATION_MZONE)>-1 end
-	Duel.Hint(HINT_SELECTMSG,tp,0)
-	local ac=Duel.AnnounceCard(tp)
-	Duel.SetTargetParam(ac)
-	Duel.SetOperationInfo(0,CATEGORY_ANNOUNCE,nil,0,tp,ANNOUNCE_CARD)
+		and e:GetHandler():IsAbleToDeck() and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
 end
-function c100000704.filter(c,ac,e,tp)
-	return c:IsType(TYPE_MONSTER) and c:IsCode(ac) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
+function c100000704.filter(c,e,tp)
+	return c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c100000704.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	local ac=Duel.GetChainInfo(0,CHAININFO_TARGET_PARAM)
-	local g=Duel.GetMatchingGroup(c100000704.filter,tp,0,LOCATION_DECK,nil,ac,e,tp)
+	local g=Duel.GetMatchingGroup(c100000704.filter,tp,0,LOCATION_DECK,nil,e,tp)
 	Duel.ConfirmCards(tp,g)
-	if g:GetCount()<=0 or not c:IsRelateToEffect(e) or not c:IsAbleToDeck() then return end
-	if Duel.SendtoDeck(c,1-tp,2,REASON_EFFECT)<=0 then return end
-	Duel.BreakEffect()
+	if g:GetCount()<=0 or Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 or not c:IsRelateToEffect(e) or not c:IsAbleToDeck() then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local tc=Duel.SelectMatchingCard(tp,c100000704.filter,tp,0,LOCATION_DECK,1,1,nil,ac,e,tp):GetFirst()
-	if tc and Duel.SpecialSummon(tc,0,tp,tp,true,false,POS_FACEUP)>0 then
-		tc:CompleteProcedure()
-	end
+	local sp=g:Select(tp,1,1,nil):GetFirst()
+	Duel.SpecialSummon(sp,0,tp,tp,false,false,POS_FACEUP)
+	Duel.BreakEffect()
+	Duel.SendtoDeck(c,1-tp,2,REASON_EFFECT)
 end
 

--- a/script/c170000167.lua
+++ b/script/c170000167.lua
@@ -92,7 +92,7 @@ function c170000167.dscon(e,tp,eg,ep,ev,re,r,rp,chk)
 	return c:IsReason(REASON_DESTROY) and  e:GetHandler():GetPreviousAttackOnField()==0 and Duel.GetLP(tp)>=10000
 end
 function c170000167.filter(c,e,tp)
-	return c:IsCode(170000170) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
+	return c:IsCode(82103466) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
 end
 function c170000167.dstg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/script/c511000275.lua
+++ b/script/c511000275.lua
@@ -10,7 +10,6 @@ function c511000275.initial_effect(c)
 	e2:SetDescription(aux.Stringid(511000275,0))
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
 	e2:SetCode(EVENT_PHASE+PHASE_DRAW)
-	e2:SetProperty(EFFECT_FLAG_REPEAT)
 	e2:SetRange(LOCATION_HAND)
 	e2:SetCountLimit(1)
 	e2:SetCondition(c511000275.accon)
@@ -36,16 +35,6 @@ function c511000275.initial_effect(c)
 	e4:SetTarget(c511000275.numtg)
 	e4:SetOperation(c511000275.numop)
 	c:RegisterEffect(e4)
-	local e5=Effect.CreateEffect(c)
-	e5:SetDescription(aux.Stringid(27346636,0))
-	e5:SetType(EFFECT_TYPE_QUICK_O)
-	e5:SetCode(EVENT_CHAINING)
-	e5:SetRange(LOCATION_SZONE)
-	e5:SetCountLimit(1,EFFECT_COUNT_CODE_SINGLE)
-	e5:SetCondition(c511000275.numcon)
-	e5:SetTarget(c511000275.numtg)
-	e5:SetOperation(c511000275.numop)
-	c:RegisterEffect(e5)
 	local e6=Effect.CreateEffect(c)
 	e6:SetDescription(aux.Stringid(93016201,0))
 	e6:SetType(EFFECT_TYPE_QUICK_O)
@@ -72,19 +61,26 @@ function c511000275.acop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c511000275.rcon(e,tp,eg,ep,ev,re,r,rp)
 	return bit.band(r,REASON_COST)~=0 and re:GetHandler():IsType(TYPE_XYZ) and ep==e:GetOwnerPlayer() and re:GetHandler():GetOverlayCount()>=ev-1
-	and re:GetHandler():IsSetCard(0x1FF)
+		and re:GetHandler():IsSetCard(0x1ff)
 end
 function c511000275.numcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetFieldGroupCount(tp,LOCATION_ONFIELD,0)==1
 end
-function c511000275.tgfilter(c,e,tp,eg,ep,ev,re,r,rp)
+function c511000275.tgfilter(c,e,tp,eg,ep,ev,re,r,rp,chain)
 	local te=c:GetActivateEffect()
 	if not c:IsSetCard(0x1ff) or not c:IsAbleToGrave() or not te then return end
 	local condition=te:GetCondition()
 	local cost=te:GetCost()
 	local target=te:GetTarget()
-	if (te:GetCode()==EVENT_FREE_CHAIN and e:GetCode()==EVENT_FREE_CHAIN) 
-		or (te:GetCode()==EVENT_CHAINING and e:GetCode()==EVENT_CHAINING) 
+	if te:GetCode()==EVENT_CHAINING then
+		if chain<=0 then return false end
+		local te2=Duel.GetChainInfo(chain,CHAININFO_TRIGGERING_EFFECT)
+		local tc=te2:GetHandler()
+		local g=Group.FromCards(tc)
+		local p=tc:GetControler()
+		return (not condition or condition(e,tp,g,p,chain,te2,REASON_EFFECT,p)) and (not cost or cost(e,tp,g,p,chain,te2,REASON_EFFECT,p,0)) 
+			and (not target or target(e,tp,g,p,chain,te2,REASON_EFFECT,p,0))
+	elseif (te:GetCode()==EVENT_FREE_CHAIN and e:GetCode()==EVENT_FREE_CHAIN) 
 		or (te:GetCode()==EVENT_SPSUMMON and e:GetCode()==EVENT_SPSUMMON) then
 		return (not condition or condition(e,tp,eg,ep,ev,re,r,rp)) and (not cost or cost(e,tp,eg,ep,ev,re,r,rp,0))
 			and (not target or target(e,tp,eg,ep,ev,re,r,rp,0))
@@ -93,25 +89,36 @@ function c511000275.tgfilter(c,e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c511000275.numtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c511000275.tgfilter,tp,LOCATION_DECK,0,1,nil,e,tp,eg,ep,ev,re,r,rp) end
+	local chain=Duel.GetCurrentChain()
+	if chk==0 then return Duel.IsExistingMatchingCard(c511000275.tgfilter,tp,LOCATION_DECK,0,1,nil,e,tp,eg,ep,ev,re,r,rp,chain) end
 	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,1,tp,LOCATION_DECK)
 end
 function c511000275.numop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.RegisterFlagEffect(tp,511001666,RESET_CHAIN,0,1)
+	Duel.RegisterFlagEffect(tp,95000027,RESET_CHAIN,0,1)
+	local chain=Duel.GetCurrentChain()-1
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-	local g=Duel.SelectMatchingCard(tp,c511000275.tgfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.SelectMatchingCard(tp,c511000275.tgfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp,eg,ep,ev,re,r,rp,chain)
 	local tc=g:GetFirst()
 	if tc and Duel.SendtoGrave(g,REASON_EFFECT)>0 then
 		local te=tc:GetActivateEffect()
-		e:SetLabelObject(te)
-		Duel.ClearTargetCard()
 		local cost=te:GetCost()
-		if cost then cost(e,tp,eg,ep,ev,re,r,rp,1) end
 		local tg=te:GetTarget()
+		local op=te:GetOperation()
 		e:SetCategory(te:GetCategory())
 		e:SetProperty(te:GetProperty())
-		if tg then tg(e,tp,eg,ep,ev,re,r,rp,1) end
-		local op=te:GetOperation()
-		if op then op(e,tp,eg,ep,ev,re,r,rp) end
+		if te:GetCode()==EVENT_CHAINING then
+			local te2=Duel.GetChainInfo(chain,CHAININFO_TRIGGERING_EFFECT)
+			local tc=te2:GetHandler()
+			local g=Group.FromCards(tc)
+			local p=tc:GetControler()
+			if co then co(e,tp,g,p,chain,te2,REASON_EFFECT,p,1) end
+			if tg then tg(e,tp,g,p,chain,te2,REASON_EFFECT,p,1) end
+			if op then op(e,tp,g,p,chain,te2,REASON_EFFECT,p) end
+		else
+			if cost then cost(e,tp,eg,ep,ev,re,r,rp,1) end
+			if tg then tg(e,tp,eg,ep,ev,re,r,rp,1) end
+			if op then op(e,tp,eg,ep,ev,re,r,rp) end
+		end
 	end
 end

--- a/script/c511001665.lua
+++ b/script/c511001665.lua
@@ -19,8 +19,8 @@ function c511001665.condition(e,tp,eg,ep,ev,re,r,rp)
 end
 function c511001665.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsChainNegatable(ev) and Duel.IsChainDisablable(ev) end
-	Duel.NegateActivation(ev)
-	Duel.NegateEffect(ev)
+	--Duel.NegateActivation(ev)
+	--Duel.NegateEffect(ev)
 end
 function c511001665.filter(c,tp,eg,ep,ev,re,r,rp)
 	local te=c:GetActivateEffect()
@@ -34,6 +34,8 @@ function c511001665.filter(c,tp,eg,ep,ev,re,r,rp)
 end
 function c511001665.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c511001665.filter,tp,0,LOCATION_DECK,1,nil,tp,eg,ep,ev,re,r,rp) end
+	Duel.NegateActivation(ev)
+	Duel.NegateEffect(ev)
 end
 function c511001665.activate(e,tp,eg,ep,ev,re,r,rp)
 	local sg=Duel.GetMatchingGroup(c511001665.filter,tp,0,LOCATION_DECK,nil,tp,eg,ep,ev,re,r,rp)

--- a/script/c511002005.lua
+++ b/script/c511002005.lua
@@ -1,12 +1,15 @@
 --Performapal Extra Shooter
 function c511002005.initial_effect(c)
 	--pendulum summon
-	aux.EnablePendulumAttribute(c,false)
-	--Activate
+	aux.EnablePendulumAttribute(c)
 	local e1=Effect.CreateEffect(c)
-	e1:SetType(EFFECT_TYPE_ACTIVATE)
-	e1:SetCode(EVENT_FREE_CHAIN)
-	e1:SetOperation(c511002005.activate)
+	e1:SetDescription(aux.Stringid(95100067,0))
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
+	e1:SetCode(511002005)
+	e1:SetRange(LOCATION_PZONE)
+	e1:SetTarget(c511002005.sctg)
+	e1:SetOperation(c511002005.scop)
 	c:RegisterEffect(e1)
 	--lvup
 	local e2=Effect.CreateEffect(c)
@@ -26,21 +29,30 @@ function c511002005.initial_effect(c)
 	e3:SetTarget(c511002005.lvtg2)
 	e3:SetOperation(c511002005.lvop2)
 	c:RegisterEffect(e3)
-end
-function c511002005.activate(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if c:IsRelateToEffect(e) then
-		local e2=Effect.CreateEffect(c)
-		e2:SetDescription(aux.Stringid(95100067,0))
-		e2:SetType(EFFECT_TYPE_IGNITION)
-		e2:SetRange(LOCATION_PZONE)
-		e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
-		e2:SetCountLimit(1)
-		e2:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
-		e2:SetTarget(c511002005.sctg)
-		e2:SetOperation(c511002005.scop)
-		c:RegisterEffect(e2)
+	if not c511002005.global_check then
+		c511002005.global_check=true
+		local ge2=Effect.CreateEffect(c)
+		ge2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge2:SetCode(EVENT_ADJUST)
+		ge2:SetOperation(c511002005.checkop)
+		Duel.RegisterEffect(ge2,0)
 	end
+end
+function c511002005.cfilter(c)
+	if not c:IsLocation(LOCATION_SZONE) then return false end
+	local seq=c:GetSequence()
+	if seq~=6 and seq~=7 then return false end
+	return c:GetFlagEffect(511002005+seq)==0 and (not c:IsPreviousLocation(LOCATION_SZONE) or c:GetPreviousSequence()~=seq)
+end
+function c511002005.checkop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(c511002005.cfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
+	local tc=g:GetFirst()
+	while tc do
+		tc:ResetFlagEffect(511002005+13-tc:GetSequence())
+		Duel.RaiseSingleEvent(tc,511002005,e,0,tp,tp,0)
+		tc:RegisterFlagEffect(511002005+tc:GetSequence(),RESET_EVENT+0x1fe0000,0,1)
+		tc=g:GetNext()
+    end
 end
 function c511002005.filter(c)
 	return c:IsFaceup() and c:IsType(TYPE_PENDULUM)
@@ -49,7 +61,7 @@ function c511002005.sctg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_SZONE) and c511002005.filter(chkc) end
 	if chk==0 then return Duel.IsExistingMatchingCard(c511002005.filter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
-	Duel.SelectMatchingCard(tp,c511002005.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SelectTarget(tp,c511002005.filter,tp,LOCATION_MZONE,0,1,1,nil)
 end
 function c511002005.scop(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end

--- a/script/c511002013.lua
+++ b/script/c511002013.lua
@@ -2,7 +2,7 @@
 function c511002013.initial_effect(c)
 	--fusion material
 	c:EnableReviveLimit()
-	aux.AddFusionProcFun2(c,c511002013.ffilter,aux.FilterBoolFunction(Card.IsFusionSetCard,0x407),true)
+	aux.AddFusionProcFun2(c,c511002013.ffilter1,c511002013.ffilter2,true)
 	--atkdown
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_ATKCHANGE)
@@ -12,8 +12,26 @@ function c511002013.initial_effect(c)
 	e1:SetOperation(c511002013.atkop)
 	c:RegisterEffect(e1)
 end
-function c511002013.ffilter(c)
-	return c:IsFusionSetCard(0x408) or c:IsFusionSetCard(0x21f) or c:IsFusionSetCard(0x21) or c:IsFusionCode(67105242) or c:IsFusionCode(67987302)
+c511002013.earth_collection={
+	[42685062]=true;[76052811]=true;[71564150]=true;[77827521]=true;[75375465]=true;
+	[70595331]=true;[67987302]=true;[94773007]=true;[45042329]=true;
+}
+c511002013.sky_collection={
+	[10000020]=true;[79575620]=true;[32559361]=true;[77998771]=true;[15914410]=true;
+	[49771608]=true;[61777313]=true;[40844552]=true;[76348260]=true;[2356994]=true;
+	[53334641]=true;[3629090]=true;[77235086]=true;[16972957]=true;[42216237]=true;
+	[42418084]=true;[59509952]=true;[18378582]=true;[81146288]=true;[85399281]=true;
+	[58601383]=true;[86327225]=true;[41589166]=true;[37910722]=true;[12171659]=true;
+	[75326861]=true;[2519690]=true;[96570609]=true;[95457011]=true;[74841885]=true;
+	[11458071]=true;[48453776]=true;[90122655]=true;[69865139]=true;[32995007]=true;
+	[1992816]=true;[80764541]=true;[87390067]=true;[3072808]=true;[49674183]=true;
+	[42431843]=true;[29146185]=true;[69992868]=true;[96470883]=true;[10028593]=true;
+}
+function c511002013.ffilter1(c)
+	return c:IsFusionSetCard(0x408) or c:IsFusionSetCard(0x21f) or c:IsFusionSetCard(0x21) or c511002013.earth_collection[c:GetFusionCode()])
+end
+function c511002013.ffilter2(c)
+	return c:IsFusionSetCard(0x407) or c:IsFusionSetCard(0xef) or c511002013.sky_collection[c:GetFusionCode()])
 end
 function c511002013.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/script/c511002014.lua
+++ b/script/c511002014.lua
@@ -2,13 +2,31 @@
 function c511002014.initial_effect(c)
 	--fusion material
 	c:EnableReviveLimit()
-	aux.AddFusionProcFun2(c,c511002014.ffilter,aux.FilterBoolFunction(Card.IsFusionSetCard,0x407),true)
+	aux.AddFusionProcFun2(c,c511002014.ffilter1,c511002014.ffilter2,true)
 	--pierce
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_PIERCE)
 	c:RegisterEffect(e1)
 end
-function c511002014.ffilter(c)
-	return c:IsFusionSetCard(0x408) or c:IsFusionSetCard(0x21f) or c:IsFusionSetCard(0x21) or c:IsFusionCode(67105242) or c:IsFusionCode(67987302)
+c511002014.earth_collection={
+	[42685062]=true;[76052811]=true;[71564150]=true;[77827521]=true;[75375465]=true;
+	[70595331]=true;[67987302]=true;[94773007]=true;[45042329]=true;
+}
+c511002014.sky_collection={
+	[10000020]=true;[79575620]=true;[32559361]=true;[77998771]=true;[15914410]=true;
+	[49771608]=true;[61777313]=true;[40844552]=true;[76348260]=true;[2356994]=true;
+	[53334641]=true;[3629090]=true;[77235086]=true;[16972957]=true;[42216237]=true;
+	[42418084]=true;[59509952]=true;[18378582]=true;[81146288]=true;[85399281]=true;
+	[58601383]=true;[86327225]=true;[41589166]=true;[37910722]=true;[12171659]=true;
+	[75326861]=true;[2519690]=true;[96570609]=true;[95457011]=true;[74841885]=true;
+	[11458071]=true;[48453776]=true;[90122655]=true;[69865139]=true;[32995007]=true;
+	[1992816]=true;[80764541]=true;[87390067]=true;[3072808]=true;[49674183]=true;
+	[42431843]=true;[29146185]=true;[69992868]=true;[96470883]=true;[10028593]=true;
+}
+function c511002014.ffilter1(c)
+	return c:IsFusionSetCard(0x408) or c:IsFusionSetCard(0x21f) or c:IsFusionSetCard(0x21) or c511002014.earth_collection[c:GetFusionCode()])
+end
+function c511002014.ffilter2(c)
+	return c:IsFusionSetCard(0x407) or c:IsFusionSetCard(0xef) or c511002014.sky_collection[c:GetFusionCode()])
 end

--- a/script/c511002015.lua
+++ b/script/c511002015.lua
@@ -2,7 +2,7 @@
 function c511002015.initial_effect(c)
 	--fusion material
 	c:EnableReviveLimit()
-	aux.AddFusionProcFun2(c,c511002015.ffilter,aux.FilterBoolFunction(Card.IsFusionSetCard,0x407),true)
+	aux.AddFusionProcFun2(c,c511002015.ffilter1,c511002015.ffilter2,true)
 	--damage
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_DAMAGE)
@@ -15,8 +15,26 @@ function c511002015.initial_effect(c)
 	e1:SetOperation(c511002015.damop)
 	c:RegisterEffect(e1)
 end
-function c511002015.ffilter(c)
-	return c:IsFusionSetCard(0x408) or c:IsFusionSetCard(0x21f) or c:IsFusionSetCard(0x21) or c:IsFusionCode(67105242) or c:IsFusionCode(67987302)
+c511002015.earth_collection={
+	[42685062]=true;[76052811]=true;[71564150]=true;[77827521]=true;[75375465]=true;
+	[70595331]=true;[67987302]=true;[94773007]=true;[45042329]=true;
+}
+c511002015.sky_collection={
+	[10000020]=true;[79575620]=true;[32559361]=true;[77998771]=true;[15914410]=true;
+	[49771608]=true;[61777313]=true;[40844552]=true;[76348260]=true;[2356994]=true;
+	[53334641]=true;[3629090]=true;[77235086]=true;[16972957]=true;[42216237]=true;
+	[42418084]=true;[59509952]=true;[18378582]=true;[81146288]=true;[85399281]=true;
+	[58601383]=true;[86327225]=true;[41589166]=true;[37910722]=true;[12171659]=true;
+	[75326861]=true;[2519690]=true;[96570609]=true;[95457011]=true;[74841885]=true;
+	[11458071]=true;[48453776]=true;[90122655]=true;[69865139]=true;[32995007]=true;
+	[1992816]=true;[80764541]=true;[87390067]=true;[3072808]=true;[49674183]=true;
+	[42431843]=true;[29146185]=true;[69992868]=true;[96470883]=true;[10028593]=true;
+}
+function c511002015.ffilter1(c)
+	return c:IsFusionSetCard(0x408) or c:IsFusionSetCard(0x21f) or c:IsFusionSetCard(0x21) or c511002015.earth_collection[c:GetFusionCode()])
+end
+function c511002015.ffilter2(c)
+	return c:IsFusionSetCard(0x407) or c:IsFusionSetCard(0xef) or c511002015.sky_collection[c:GetFusionCode()])
 end
 function c511002015.filter(c)
 	return c:IsFaceup() and c:IsRace(RACE_WARRIOR)

--- a/script/c511002193.lua
+++ b/script/c511002193.lua
@@ -73,6 +73,7 @@ function c511002193.desop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ConfirmCards(tp,hg)
 		local dg=hg:Filter(Card.IsType,nil,e:GetLabel())
 		Duel.Destroy(dg,REASON_EFFECT)
+		Duel.ShuffleHand(1-tp)
 	end
-	e:GetLabelObject():SetDescription(0)
+	e:SetDescription(0)
 end

--- a/script/c511002358.lua
+++ b/script/c511002358.lua
@@ -19,5 +19,5 @@ function c511002358.indval(e,c)
 	return c:IsLevelAbove(4)
 end
 function c511002358.efilter(e,te)
-	return te:IsActiveType(TYPE_MONSTER) and te:IsLevelAbove(4)
+	return te:IsActiveType(TYPE_MONSTER) and te:GetHandler():IsLevelAbove(4)
 end

--- a/script/c511005630.lua
+++ b/script/c511005630.lua
@@ -1,0 +1,39 @@
+--Freedom Bird
+--scripted by GameMaster (GM)
+--fixed by MLD
+function c511005630.initial_effect(c)
+	--Special summon Freedom bird from you deck
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(511005630,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCode(EVENT_SUMMON_SUCCESS)
+	e1:SetCondition(c511005630.spcon)	
+	e1:SetTarget(c511005630.sptg)
+	e1:SetOperation(c511005630.spop)
+	c:RegisterEffect(e1)
+	local e2=e1:Clone()
+	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
+	c:RegisterEffect(e2)
+end
+function c511005630.cfilter(c,tp)
+	return c:GetSummonPlayer()~=tp
+end
+function c511005630.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(c511005630.cfilter,1,nil,tp)
+end
+function c511005630.filter(c,e,tp)
+	return c:IsCode(511005630) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c511005630.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c511005630.filter,tp,LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function c511005630.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c511005630.filter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+	Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+end

--- a/script/c511009027.lua
+++ b/script/c511009027.lua
@@ -2,36 +2,37 @@
 function c511009027.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
-	e1:SetCategory(CATEGORY_TOHAND)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
-	e1:SetCondition(c511009027.condition)
 	e1:SetTarget(c511009027.target)
 	e1:SetOperation(c511009027.activate)
 	c:RegisterEffect(e1)
 end
-function c511009027.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetAttackTarget():IsType(TYPE_XYZ) and Duel.IsExistingMatchingCard(c511009027.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,Duel.GetAttackTarget(),Duel.GetAttackTarget():GetRank()+1)
+function c511009027.filter(c,e,tp)
+	return c:IsType(TYPE_XYZ) and c:IsFaceup() 
+		and Duel.IsExistingMatchingCard(c511009027.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,c,c:GetRank()+1,c:GetCode())
 end
-function c511009027.filter2(c,e,tp,mc,rk)
+function c511009027.filter2(c,e,tp,mc,rk,code)
+	if c:GetOriginalCode()==6165656 and code~=48995978 then return false end
 	return c:GetRank()==rk and mc:IsCanBeXyzMaterial(c)
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_XYZ,tp,false,false)
 end
 function c511009027.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local tg=Duel.GetAttackTarget()
-	if chkc then return chkc==tg end
-	if chk==0 then return tg:IsOnField() and tg:IsCanBeEffectTarget(e) end
+	if chkc then return chkc==tg and c511009027.filter(chkc,e,tp) end
+	if chk==0 then return tg and tg:IsOnField() and tg:IsCanBeEffectTarget(e) and c511009027.filter(tg,e,tp) end
 	Duel.SetTargetCard(tg)
-	Duel.SetOperationInfo(0,CATEGORY_TOHAND,tg,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function c511009027.activate(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<0 then return end
 	local tc=Duel.GetFirstTarget()
-	if tc:IsFacedown() or not tc:IsRelateToEffect(e) or tc:IsControler(1-tp) or tc:IsImmuneToEffect(e) then return end
+	if not tc or tc:IsFacedown() or not tc:IsRelateToEffect(e) or tc:IsControler(1-tp) or tc:IsImmuneToEffect(e) then return end
 	Duel.NegateAttack()
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectMatchingCard(tp,c511009027.filter2,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,tc,tc:GetRank()+1)
+	local g=Duel.SelectMatchingCard(tp,c511009027.filter2,tp,LOCATION_EXTRA,0,1,1,nil,e,tp,tc,tc:GetRank()+1,tc:GetCode())
 	local sc=g:GetFirst()
 	if sc then
 		local mg=tc:GetOverlayGroup()

--- a/script/c511009325.lua
+++ b/script/c511009325.lua
@@ -5,17 +5,16 @@ function c511009325.initial_effect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_BATTLE_DAMAGE)
-	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e1:SetCondition(c511009325.condition)
 	e1:SetTarget(c511009325.target)
 	e1:SetOperation(c511009325.activate)
 	c:RegisterEffect(e1)
-	
-	
 	--to hand
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(18563744,1))
 	e2:SetCategory(CATEGORY_ATKCHANGE)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e2:SetType(EFFECT_TYPE_IGNITION)
 	e2:SetRange(LOCATION_GRAVE)
 	e2:SetCost(c511009325.atkcost)
@@ -67,8 +66,6 @@ function c511009325.activate(e,tp,eg,ep,ev,re,r,rp)
 		Duel.XyzSummon(tp,xyz,g)
 	end
 end
-
---atk up
 function c511009325.atkcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToRemoveAsCost() end
 	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
@@ -76,15 +73,15 @@ end
 function c511009325.atkfilter(c)
 	return c:IsFaceup() and c:IsType(TYPE_XYZ) and c:GetOverlayCount()>0
 end
-function c511009325.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+function c511009325.atktg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c511009325.atkfilter(chkc) end
 	if chk==0 then return Duel.IsExistingTarget(c511009325.atkfilter,tp,LOCATION_MZONE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
 	Duel.SelectTarget(tp,c511009325.atkfilter,tp,LOCATION_MZONE,0,1,1,nil)
 end
-function c511009325.activate(e,tp,eg,ep,ev,re,r,rp)
+function c511009325.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
 		local ct=tc:GetOverlayCount()
 		tc:RemoveOverlayCard(tp,ct,ct,REASON_EFFECT)
 		local e1=Effect.CreateEffect(e:GetHandler())

--- a/script/c511009328.lua
+++ b/script/c511009328.lua
@@ -3,23 +3,21 @@ function c511009328.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(44968459,0))
-	e1:SetCategory(CATEGORY_DRAW)
+	e1:SetCategory(CATEGORY_DESTROY)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
-	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_CANNOT_NEGATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetCondition(c511009328.condition)
 	e1:SetCost(c511009328.cost)
 	e1:SetTarget(c511009328.target)
 	e1:SetOperation(c511009328.activate)
-	c:RegisterEffect(e1)
-	
+	c:RegisterEffect(e1)	
 	if not c511009328.global_check then
 		c511009328.global_check=true
 		c511009328[0]=0
 		c511009328[1]=0
 		local ge1=Effect.CreateEffect(c)
+		ge1:SetProperty(EFFECT_FLAG_DAMAGE_STEP)
 		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-		ge1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
 		ge1:SetCode(EVENT_TO_GRAVE)
 		ge1:SetOperation(c511009328.op)
 		Duel.RegisterEffect(ge1,0)
@@ -45,15 +43,15 @@ function c511009328.condition(e,tp,eg,ep,ev,re,r,rp)
 	return ph>=PHASE_BATTLE_START and ph<=PHASE_BATTLE
 end
 function c511009328.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return  Duel.IsExistingMatchingCard(aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil)
-	end
+	if chk==0 then return  Duel.IsExistingMatchingCard(aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 	local g=Duel.GetMatchingGroup(aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
 end
 function c511009328.activate(e,tp,eg,ep,ev,re,r,rp)
 	local dg=Duel.GetMatchingGroup(aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
-    Duel.Destroy(dg,REASON_EFFECT)
-	--draw
+	Duel.Destroy(dg,REASON_EFFECT)
+	Duel.BreakEffect()
+	Duel.SkipPhase(Duel.GetTurnPlayer(),PHASE_BATTLE,RESET_PHASE+PHASE_BATTLE,1)
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 	e1:SetCode(EVENT_PHASE+PHASE_BATTLE)
@@ -62,21 +60,22 @@ function c511009328.activate(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetReset(RESET_PHASE+PHASE_BATTLE)
 	Duel.RegisterEffect(e1,tp)
 end
-
---register
 function c511009328.chkfilter(c,tp)
 	return c:IsType(TYPE_MONSTER) and c:IsLocation(LOCATION_GRAVE) 
 		and c:GetPreviousControler()==tp
 end
 function c511009328.op(e,tp,eg,ep,ev,re,r,rp)
+	if eg==nil or eg:GetCount()<=0 then return end
 	local ph=Duel.GetCurrentPhase()
-	local ct1=eg:FilterCount(c511009328.chkfilter,nil,tp)
-	local ct2=eg:FilterCount(c511009328.chkfilter,nil,1-tp)
-	if ct1>0 and ph>=PHASE_BATTLE_START and ph<=PHASE_BATTLE then
-		c511009328[0]=c511009328[0]+ct1
-	end
-	if ct2>0 and ph>=PHASE_BATTLE_START and ph<=PHASE_BATTLE then
-		c511009328[1]=c511009328[1]+ct2
+	if ph>=0x08 and ph<=0x20 then
+		local ct1=eg:FilterCount(c511009328.chkfilter,nil,tp)
+		local ct2=eg:FilterCount(c511009328.chkfilter,nil,1-tp)
+		if ct1>0 then
+			c511009328[tp]=c511009328[tp]+ct1
+		end
+		if ct2>0 then
+			c511009328[1-tp]=c511009328[1-tp]+ct2
+		end
 	end
 end
 function c511009328.clear(e,tp,eg,ep,ev,re,r,rp)
@@ -86,7 +85,7 @@ end
 function c511009328.damop(e,tp,eg,ep,ev,re,r,rp)
 	if c511009328[0]>0 or c511009328[1]>0 then
 		Duel.Hint(HINT_CARD,0,511009328)
-		Duel.Damage(tp,c511009328[1]*800,REASON_EFFECT)
-		Duel.Damage(1-tp,c511009328[0]*800,REASON_EFFECT)
+		Duel.Damage(tp,c511009328[tp]*800,REASON_EFFECT)
+		Duel.Damage(1-tp,c511009328[1-tp]*800,REASON_EFFECT)
 	end
 end

--- a/script/c511012001.lua
+++ b/script/c511012001.lua
@@ -3,6 +3,13 @@
 function c511012001.initial_effect(c)
 	--pendulum summon
 	aux.EnablePendulumAttribute(c)
+	--cannot destroy
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e1:SetCode(511012000)
+	e1:SetRange(LOCATION_PZONE)
+	c:RegisterEffect(e1)
 	--reduce
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(16178681,0))
@@ -24,11 +31,24 @@ function c511012001.rdcon(e,tp,eg,ep,ev,re,r,rp)
 	if e:GetHandler():GetFlagEffect(511012001)>0 then return false end
 	local tc=Duel.GetAttacker()
 	if tc:IsControler(1-tp) then tc=Duel.GetAttackTarget() end
-	return ep==tp and tc and tc:IsType(TYPE_PENDULUM)
+	return ep==tp and tc and tc:IsType(TYPE_PENDULUM) and Duel.GetBattleDamage(tp)>0
 end
 function c511012001.rdop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.SelectYesNo(tp,aux.Stringid(16178681,2)) then
-		e:GetHandler():RegisterFlagEffect(511012001,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+	local pc1=e:GetHandler()
+	local pc2=Duel.GetFieldCard(tp,LOCATION_SZONE,13-pc1:GetSequence())
+	local g
+	if pc2 and pc2:IsHasEffect(511012000) and pc2:GetFlagEffect(511012001)==0 then
+		g=Group.FromCards(pc1,pc2)
+	else
+		g=Group.FromCards(pc1)
+	end
+	if Duel.GetFlagEffect(tp,511012001)==0 and Duel.SelectYesNo(tp,aux.Stringid(16178681,2)) then
+		if g:GetCount()>1 then g=g:Select(tp,1,1,nil) end
+		Duel.HintSelection(g)
+		Duel.Hint(HINT_CARD,0,511012001)
+		local tc=g:GetFirst()
+		Duel.RegisterFlagEffect(tp,511012001,RESET_PHASE+PHASE_DAMAGE,0,1)
+		tc:RegisterFlagEffect(511012001,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
 		Duel.ChangeBattleDamage(tp,0)
 	end
 end

--- a/script/c511012001.lua
+++ b/script/c511012001.lua
@@ -1,0 +1,41 @@
+--オッドアイズ・ペンデュラム・ドラゴン
+--fixed by MLD
+function c511012001.initial_effect(c)
+	--pendulum summon
+	aux.EnablePendulumAttribute(c)
+	--reduce
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(16178681,0))
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EVENT_PRE_BATTLE_DAMAGE)
+	e2:SetRange(LOCATION_PZONE)
+	e2:SetCondition(c511012001.rdcon)
+	e2:SetOperation(c511012001.rdop)
+	c:RegisterEffect(e2)
+	--double
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e4:SetCode(EVENT_PRE_BATTLE_DAMAGE)
+	e4:SetCondition(c511012001.damcon)
+	e4:SetOperation(c511012001.damop)
+	c:RegisterEffect(e4)
+end
+function c511012001.rdcon(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():GetFlagEffect(511012001)>0 then return false end
+	local tc=Duel.GetAttacker()
+	if tc:IsControler(1-tp) then tc=Duel.GetAttackTarget() end
+	return ep==tp and tc and tc:IsType(TYPE_PENDULUM)
+end
+function c511012001.rdop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.SelectYesNo(tp,aux.Stringid(16178681,2)) then
+		e:GetHandler():RegisterFlagEffect(511012001,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+		Duel.ChangeBattleDamage(tp,0)
+	end
+end
+function c511012001.damcon(e,tp,eg,ep,ev,re,r,rp)
+	local bc=e:GetHandler():GetBattleTarget()
+	return ep~=tp and bc and bc:IsLevelAbove(5) and bc:IsControler(1-tp)
+end
+function c511012001.damop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.ChangeBattleDamage(ep,ev*2)
+end

--- a/script/c700000022.lua
+++ b/script/c700000022.lua
@@ -1,0 +1,76 @@
+--追走の翼
+function c700000022.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(0,0x1e0)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetTarget(c700000022.target)
+	e1:SetOperation(c700000022.operation)
+	c:RegisterEffect(e1)
+end
+function c700000022.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and chkc:IsFaceup() end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,0,1,1,nil)
+end
+function c700000022.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if c:IsRelateToEffect(e) and tc and tc:IsFaceup() and tc:IsRelateToEffect(e) then
+		c:SetCardTarget(tc)
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE+EFFECT_FLAG_OWNER_RELATE)
+		e1:SetRange(LOCATION_MZONE)
+		e1:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		e1:SetCondition(c700000022.rcon)
+		e1:SetValue(1)
+		tc:RegisterEffect(e1,true)
+		local e3=Effect.CreateEffect(c)
+		e3:SetDescription(aux.Stringid(42776855,0))
+		e3:SetCategory(CATEGORY_DESTROY)
+		e3:SetType(EFFECT_TYPE_QUICK_O)
+		e3:SetCode(EVENT_BATTLE_START)
+		e3:SetRange(LOCATION_SZONE)
+		e3:SetCondition(c700000022.atkcon)
+		e3:SetTarget(c700000022.atktg)
+		e3:SetOperation(c700000022.atkop)
+		e3:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e3)
+	end
+end
+function c700000022.rcon(e)
+	return e:GetOwner():IsHasCardTarget(e:GetHandler())
+end
+function c700000022.atkcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=c:GetFirstCardTarget()
+	if not tc then return false end
+	local bc=tc:GetBattleTarget()
+	return tc and tc:IsLocation(LOCATION_MZONE) and bc and bc:IsFaceup() and bc:IsLocation(LOCATION_MZONE) and bc:IsLevelAbove(5) 
+		and bc==Duel.GetAttacker()
+end
+function c700000022.atktg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():GetFlagEffect(42776855)==0 end
+	e:GetHandler():RegisterFlagEffect(42776855,RESET_CHAIN,0,1)
+end
+function c700000022.atkop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	local tc=c:GetFirstCardTarget()
+	if not tc then return false end
+	local bc=tc:GetBattleTarget()
+	local atk=bc:GetAttack()
+	if bc:IsRelateToBattle() and Duel.Destroy(bc,REASON_EFFECT)~=0 then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(atk)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		tc:RegisterEffect(e1)
+	end
+end

--- a/script/c700000027.lua
+++ b/script/c700000027.lua
@@ -15,29 +15,36 @@ function c700000027.initial_effect(c)
 	e1:SetOperation(c700000027.operation)
 	c:RegisterEffect(e1)
 end
-
 function c700000027.cost(e,tp,ep,eg,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end
 	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
 end
+function c700000027.filter(c,e)
+	return aux.nzatk(c) and (not e or not c:IsImmuneToEffect(e))
+end
 function c700000027.target(e,tp,ep,eg,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(aux.nzatk,tp,0,LOCATION_MZONE,1,nil) and Duel.IsExistingMatchingCard(Card.IsSetCard,tp,LOCATION_GRAVE,0,1,nil,0xba) end
+	if chk==0 then return Duel.IsExistingMatchingCard(aux.nzatk,tp,0,LOCATION_MZONE,1,nil) 
+		and Duel.IsExistingMatchingCard(Card.IsSetCard,tp,LOCATION_GRAVE,0,1,nil,0xba) end
 end
 function c700000027.operation(e,tp,ep,eg,ev,re,r,rp)
-	local mg=Duel.GetMatchingGroupCount(c700000027.filter1,tp,0,LOCATION_MZONE,nil)
+	local mg=Duel.GetMatchingGroupCount(c700000027.filter,tp,0,LOCATION_MZONE,nil,e)
 	local rc=Duel.GetMatchingGroupCount(Card.IsSetCard,tp,LOCATION_GRAVE,0,nil,0xba)
 	if mg==0 or rc==0 then return end
-	local b=true
-	while rc>0 and b and Duel.IsExistingMatchingCard(aux.nzatk,tp,0,LOCATION_MZONE,1,nil) do
-		local tg=Duel.SelectMatchingCard(tp,aux.nzatk,tp,0,LOCATION_MZONE,1,1,nil)
+	repeat
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+		local tg=Duel.SelectMatchingCard(tp,c700000027.filter,tp,0,LOCATION_MZONE,1,1,nil,e)
 		local tc=tg:GetFirst()
-		local e1=Effect.CreateEffect(e:GetHandler())
-		e1:SetType(EFFECT_TYPE_SINGLE)
-		e1:SetCode(EFFECT_UPDATE_ATTACK)
-		e1:SetValue(-800)
-		e1:SetReset(RESET_EVENT+0x1ff0000)
-		tc:RegisterEffect(e1)
+		if tc then
+			Duel.HintSelection(tg)
+			local e1=Effect.CreateEffect(e:GetHandler())
+			e1:SetType(EFFECT_TYPE_SINGLE)
+			e1:SetCode(EFFECT_UPDATE_ATTACK)
+			e1:SetValue(-800)
+			e1:SetReset(RESET_EVENT+0x1fe0000)
+			tc:RegisterEffect(e1)
+		else return
+		end
 		rc=rc-1
-		if rc>0 and Duel.IsExistingMatchingCard(aux.nzatk,tp,0,LOCATION_MZONE,1,nil) then b=Duel.SelectYesNo(tp,aux.Stringid(6528,8)) end
-	end
+	until rc<=0 or not Duel.IsExistingMatchingCard(c700000027.filter,tp,0,LOCATION_MZONE,1,nil,e) 
+		or not Duel.SelectYesNo(tp,210)
 end

--- a/script/c700000027.lua
+++ b/script/c700000027.lua
@@ -22,13 +22,16 @@ end
 function c700000027.filter(c,e)
 	return aux.nzatk(c) and (not e or not c:IsImmuneToEffect(e))
 end
+function c700000027.cfilter(c)
+	return c:IsSetCard(0xba) and c:IsType(TYPE_MONSTER)
+end
 function c700000027.target(e,tp,ep,eg,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(aux.nzatk,tp,0,LOCATION_MZONE,1,nil) 
-		and Duel.IsExistingMatchingCard(Card.IsSetCard,tp,LOCATION_GRAVE,0,1,nil,0xba) end
+		and Duel.IsExistingMatchingCard(c700000027.cfilter,tp,LOCATION_GRAVE,0,1,nil) end
 end
 function c700000027.operation(e,tp,ep,eg,ev,re,r,rp)
 	local mg=Duel.GetMatchingGroupCount(c700000027.filter,tp,0,LOCATION_MZONE,nil,e)
-	local rc=Duel.GetMatchingGroupCount(Card.IsSetCard,tp,LOCATION_GRAVE,0,nil,0xba)
+	local rc=Duel.GetMatchingGroupCount(c700000027.cfilter,tp,LOCATION_GRAVE,0,nil)
 	if mg==0 or rc==0 then return end
 	repeat
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)

--- a/script/c700000029.lua
+++ b/script/c700000029.lua
@@ -1,9 +1,10 @@
 --Scripted by Eerie Code
 --Bloom Prima the Melodious Choir
+--fixed by MLD
 function c700000029.initial_effect(c)
 	--fusion material
 	c:EnableReviveLimit()
-	aux.AddFusionProcFun2(c,c700000029.mfilter1,c700000029.mfilter2,true)
+	aux.AddFusionProcFunFunRep(c,c700000029.mfilter1,aux.FilterBoolFunction(Card.IsFusionSetCard,0x9b),1,63,true)
 	--summon success
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE)
@@ -16,34 +17,16 @@ function c700000029.initial_effect(c)
 	e3:SetValue(1)
 	c:RegisterEffect(e3)
 end
-
 function c700000029.mfilter1(c)
-	local code=c:GetCode()
-	return code==62895219 or code==14763299
-	--return (c:IsCode(62895219) or c:IsCode(6812)) and mg:IsExists(c700000029.mfilter2,1,c)
-end
-function c700000029.mfilter2(c)
-	return c:IsSetCard(0x9b)
-end
-function c700000029.fscon(e,mg,gc)
-	if mg==nil then return true end
-	if gc then return false end
-	return mg:IsExists(c700000029.mfilter1,1,nil,mg)
-end
-function c700000029.fsop(e,tp,eg,ep,ev,re,r,rp,gc)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
-	local g1=eg:FilterSelect(tp,c700000029.mfilter1,1,1,nil,eg)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
-	local g2=eg:FilterSelect(tp,c700000029.mfilter2,1,63,g1:GetFirst())
-	g1:Merge(g2)
-	Duel.SetFusionMaterial(g1)
+	local code=c:GetFusionCode()
+	return code==14763299 or code==62895219
 end
 function c700000029.matcheck(e,c)
 	local ct=c:GetMaterialCount()
-	local ae=Effect.CreateEffect(c)
-	ae:SetType(EFFECT_TYPE_SINGLE)
-	ae:SetCode(EFFECT_UPDATE_ATTACK)
-	ae:SetValue(ct*300)
-	ae:SetReset(RESET_EVENT+0xff0000)
-	c:RegisterEffect(ae)
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_UPDATE_ATTACK)
+	e1:SetValue(ct*300)
+	e1:SetReset(RESET_EVENT+0xff0000)
+	c:RegisterEffect(e1)
 end

--- a/script/c95000000.lua
+++ b/script/c95000000.lua
@@ -33,11 +33,11 @@ function c95000000.initial_effect(c)
 	local e5=Effect.CreateEffect(c)
 	e5:SetType(EFFECT_TYPE_FIELD)
 	e5:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_PLAYER_TARGET)
-	e5:SetCode(EFFECT_CANNOT_LOSE_DECK)
-	e5:SetRange(LOCATION_REMOVED)
+	e5:SetCode(EFFECT_DRAW_COUNT)
 	e5:SetTargetRange(1,0)
+	e5:SetValue(c95000000.value)
 	e5:SetCondition(c95000000.deckcon)
-	e5:SetValue(1)
+	e5:SetRange(LOCATION_REMOVED)
 	c:RegisterEffect(e5)
 	--rearrange
 	local e6=Effect.CreateEffect(c)
@@ -173,8 +173,12 @@ function c95000000.thop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SendtoHand(g,nil,REASON_RULE)
 	end
 end
+function c95000000.value(e,c)
+	return Duel.GetFieldGroupCount(e:GetHandlerPlayer(),LOCATION_DECK,0)
+end
 function c95000000.deckcon(e)
-	return Duel.GetTurnPlayer()==e:GetHandlerPlayer() and Duel.GetCurrentPhase()==PHASE_DRAW
+	local tp=e:GetHandlerPlayer()
+	return Duel.GetDrawCount(tp)>Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)
 end
 function c95000000.ordercon(e,tp,eg,ep,ev,re,r,rp)
 	local ct=1

--- a/script/c95000023.lua
+++ b/script/c95000023.lua
@@ -23,6 +23,15 @@ function c95000023.initial_effect(c)
 	e3:SetCost(c95000023.accost)
 	e3:SetOperation(c95000023.acop)
 	c:RegisterEffect(e3)
+	local e6=Effect.CreateEffect(c)
+	e6:SetDescription(aux.Stringid(93016201,0))
+	e6:SetType(EFFECT_TYPE_QUICK_O)
+	e6:SetCode(EVENT_SPSUMMON)
+	e6:SetRange(LOCATION_SZONE)
+	e6:SetCondition(c95000023.accon)
+	e6:SetTarget(c95000023.accost)
+	e6:SetOperation(c95000023.acop)
+	c:RegisterEffect(e6)
 end
 c95000023.mark=0
 function c95000023.valcon(e,re,r,rp)
@@ -31,28 +40,59 @@ end
 function c95000023.accon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetFieldGroupCount(tp,LOCATION_ONFIELD,0)<=1
 end
-function c95000023.cfilter(c)
-	return c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsAbleToGrave() and c:CheckActivateEffect(false,false,false)~=nil
+function c95000023.cfilter(c,e,tp,eg,ep,ev,re,r,rp,chain)
+	local te=c:GetActivateEffect()
+	if not te or not c:IsType(TYPE_SPELL+TYPE_TRAP) or not c:IsAbleToGraveAsCost() then return false end
+	local condition=te:GetCondition()
+	local cost=te:GetCost()
+	local target=te:GetTarget()
+	if te:GetCode()==EVENT_CHAINING then
+		if chain<=0 then return false end
+		local te2=Duel.GetChainInfo(chain,CHAININFO_TRIGGERING_EFFECT)
+		local tc=te2:GetHandler()
+		local g=Group.FromCards(tc)
+		local p=tc:GetControler()
+		return (not condition or condition(e,tp,g,p,chain,te2,REASON_EFFECT,p)) and (not cost or cost(e,tp,g,p,chain,te2,REASON_EFFECT,p,0)) 
+			and (not target or target(e,tp,g,p,chain,te2,REASON_EFFECT,p,0))
+	elseif (te:GetCode()==EVENT_SPSUMMON and e:GetCode()==EVENT_SPSUMMON) or (e:GetCode()==EVENT_FREE_CHAIN and te:GetCode()~=EVENT_SPSUMMON) then
+		return (not condition or condition(e,tp,eg,ep,ev,re,r,rp)) and (not cost or cost(e,tp,eg,ep,ev,re,r,rp,0)) 
+			and (not target or target(e,tp,eg,ep,ev,re,r,rp,0))
+	end
 end
 function c95000023.accost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c95000023.cfilter,tp,LOCATION_HAND+LOCATION_DECK,0,1,nil) end
+	local chain=Duel.GetCurrentChain()
+	if chk==0 then return Duel.IsExistingMatchingCard(c95000023.cfilter,tp,LOCATION_HAND+LOCATION_DECK,0,1,nil,e,tp,eg,ep,ev,re,r,rp,chain) end
+	chain=chain-1
+	Duel.RegisterFlagEffect(tp,511001666,RESET_CHAIN,0,1)
+	Duel.RegisterFlagEffect(tp,95000027,RESET_CHAIN,0,1)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-	local g=Duel.SelectMatchingCard(tp,c95000023.cfilter,tp,LOCATION_HAND+LOCATION_DECK,0,1,1,nil)
+	local g=Duel.SelectMatchingCard(tp,c95000023.cfilter,tp,LOCATION_HAND+LOCATION_DECK,0,1,1,nil,e,tp,eg,ep,ev,re,r,rp,chain)
 	Duel.SendtoGrave(g,REASON_COST)
 	Duel.SetTargetCard(g:GetFirst())
 end
 function c95000023.acop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc then
-		local te=tc:CheckActivateEffect(false,false,false)
+		local te=tc:GetActivateEffect()
 		if not te then return end
 		e:SetCategory(te:GetCategory())
 		e:SetProperty(te:GetProperty())
 		local co=te:GetCost()
 		local tg=te:GetTarget()
 		local op=te:GetOperation()
-		if co then co(e,tp,eg,ep,ev,re,r,rp,1) end
-		if tg then tg(e,tp,eg,ep,ev,re,r,rp,1) end
-		if op then op(e,tp,eg,ep,ev,re,r,rp) end
+		if te:GetCode()==EVENT_CHAINING then
+			local chain=Duel.GetCurrentChain()-1
+			local te2=Duel.GetChainInfo(chain,CHAININFO_TRIGGERING_EFFECT)
+			local tc=te2:GetHandler()
+			local g=Group.FromCards(tc)
+			local p=tc:GetControler()
+			if co then co(e,tp,g,p,chain,te2,REASON_EFFECT,p,1) end
+			if tg then tg(e,tp,g,p,chain,te2,REASON_EFFECT,p,1) end
+			if op then op(e,tp,g,p,chain,te2,REASON_EFFECT,p) end
+		else
+			if co then co(e,tp,eg,ep,ev,re,r,rp,1) end
+			if tg then tg(e,tp,eg,ep,ev,re,r,rp,1) end
+			if op then op(e,tp,eg,ep,ev,re,r,rp) end
+		end
 	end
 end

--- a/script/c95000027.lua
+++ b/script/c95000027.lua
@@ -12,7 +12,7 @@ function c95000027.initial_effect(c)
 end
 c95000027.mark=2
 function c95000027.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=ep and eg:GetCount()==1 and Duel.GetCurrentChain()==0
+	return tp~=ep and eg:GetCount()==1 and (Duel.GetCurrentChain()==0 or (Duel.GetFlagEffect(tp,95000027)>0 and Duel.GetCurrentChain()==1))
 end
 function c95000027.filter(c,e,tp)
 	return c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,1-tp)


### PR DESCRIPTION
Boss Duel - draw phase losing, fixed.
Don Thousand/Spell A - allows using Don Thousand/Trap A and Don Thousand/Trap B
Don Thousand/Trap A - checks for being selected by Numeron Network
Additional Check for regular Anime Numeron Network
Numeron Spell Revision - fixed issue with Negating during cost
Performapal Performage Wing Sandwichman - effect update (but requires core modification and update to completely fix Pendulum Scale issue)
Raidraptor Target Flag fix
Ice Edge unaffected by Level 4 or higher fixed
Freedom Bird fixed
Rank-Up-Magic Escape Force error when there is no attack target fixed + C88 OCG checking
The Phantom Knights of Double Badge fix
The Phantom Knights of Around Burn fix
Bloom Diva Material fix (but requires database fix to fix archetype)
