### PR TITLE
Updated "Predaplant Sundew Kingii", bug fixes

### DIFF
--- a/script/c100200124.lua
+++ b/script/c100200124.lua
@@ -5,7 +5,7 @@ function c100200124.initial_effect(c)
 	--fusion material
 	c:EnableReviveLimit()
 	if Card.IsFusionAttribute then
-		aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsType,TYPE_FUSION),aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_DARK),true)
+		aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsType,TYPE_FUSION),aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_DARK,c),true)
 	else
 		aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsType,TYPE_FUSION),aux.FilterBoolFunction(Card.IsAttribute,ATTRIBUTE_DARK),true)
 	end

--- a/script/c12307878.lua
+++ b/script/c12307878.lua
@@ -5,7 +5,7 @@ function c12307878.initial_effect(c)
 	--fusion material
 	c:EnableReviveLimit()
 	if Card.IsFusionAttribute then
-		aux.AddFusionProcCodeFun(c,86120751,aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_FIRE),1,true,true)
+		aux.AddFusionProcCodeFun(c,86120751,aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_FIRE,c),1,true,true)
 	else
 		aux.AddFusionProcCodeFun(c,86120751,aux.FilterBoolFunction(Card.IsAttribute,ATTRIBUTE_FIRE),1,true,true)
 	end

--- a/script/c13529466.lua
+++ b/script/c13529466.lua
@@ -5,7 +5,7 @@ function c13529466.initial_effect(c)
 	--fusion material
 	c:EnableReviveLimit()
 	if Card.IsFusionAttribute then
-		aux.AddFusionProcCodeFun(c,86120751,aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_DARK),1,true,true)
+		aux.AddFusionProcCodeFun(c,86120751,aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_DARK,c),1,true,true)
 	else
 		aux.AddFusionProcCodeFun(c,86120751,aux.FilterBoolFunction(Card.IsAttribute,ATTRIBUTE_DARK),1,true,true)
 	end

--- a/script/c16304628.lua
+++ b/script/c16304628.lua
@@ -3,7 +3,7 @@ function c16304628.initial_effect(c)
 	--fusion material
 	c:EnableReviveLimit()
 	if Card.IsFusionAttribute then
-		aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsFusionSetCard,0x3008),aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_EARTH),true)
+		aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsFusionSetCard,0x3008),aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_EARTH,c),true)
 	else
 		aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsFusionSetCard,0x3008),aux.FilterBoolFunction(Card.IsAttribute,ATTRIBUTE_EARTH),true)
 	end

--- a/script/c19261966.lua
+++ b/script/c19261966.lua
@@ -38,14 +38,13 @@ function c19261966.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function c19261966.ffilter1(c)
-	return c:IsFusionSetCard(0x9d)
+	return c:IsFusionSetCard(0x9d) and not c:IsHasEffect(6205579) end
 end
-function c19261966.ffilter2(c)
-	--return c:IsAttribute(ATTRIBUTE_WATER) or c:IsHasEffect(4904633)
+function c19261966.ffilter2(c,fc)
 	if Card.IsFusionAttribute then
-		return c:IsFusionAttribute(ATTRIBUTE_WATER) or c:IsHasEffect(4904633)
+		return (c:IsFusionAttribute(ATTRIBUTE_WATER,fc) or c:IsHasEffect(4904633)) and not c:IsHasEffect(6205579)
 	else
-		return c:IsAttribute(ATTRIBUTE_WATER) or c:IsHasEffect(4904633)
+		return (c:IsAttribute(ATTRIBUTE_WATER) or c:IsHasEffect(4904633)) and not c:IsHasEffect(6205579)
 	end
 end
 function c19261966.exfilter(c,g)
@@ -53,6 +52,7 @@ function c19261966.exfilter(c,g)
 end
 function c19261966.fuscon(e,g,gc,chkf)
 	if g==nil then return true end
+	local c=e:GetHandler()
 	local tp=e:GetHandlerPlayer()
 	local fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
 	local exg=Group.CreateGroup()
@@ -60,8 +60,8 @@ function c19261966.fuscon(e,g,gc,chkf)
 		local sg=Duel.GetMatchingGroup(c19261966.exfilter,tp,0,LOCATION_MZONE,nil,g)
 		exg:Merge(sg)
 	end
-	if gc then return (c19261966.ffilter1(gc) and (g:IsExists(c19261966.ffilter2,1,gc) or exg:IsExists(c19261966.ffilter2,1,gc)))
-		or (c19261966.ffilter2(gc) and (g:IsExists(c19261966.ffilter1,1,gc) or exg:IsExists(c19261966.ffilter1,1,gc))) end
+	if gc then return (c19261966.ffilter1(gc) and (g:IsExists(c19261966.ffilter2,1,gc,c) or exg:IsExists(c19261966.ffilter2,1,gc,c)))
+		or (c19261966.ffilter2(gc,c) and (g:IsExists(c19261966.ffilter1,1,gc) or exg:IsExists(c19261966.ffilter1,1,gc))) end
 	local g1=Group.CreateGroup()
 	local g2=Group.CreateGroup()
 	local g3=Group.CreateGroup()
@@ -72,14 +72,14 @@ function c19261966.fuscon(e,g,gc,chkf)
 			g1:AddCard(tc)
 			if aux.FConditionCheckF(tc,chkf) then g3:AddCard(tc) end
 		end
-		if c19261966.ffilter2(tc) then
+		if c19261966.ffilter2(tc,c) then
 			g2:AddCard(tc)
 			if aux.FConditionCheckF(tc,chkf) then g4:AddCard(tc) end
 		end
 		tc=g:GetNext()
 	end
 	local exg1=exg:Filter(c19261966.ffilter1,nil)
-	local exg2=exg:Filter(c19261966.ffilter2,nil)
+	local exg2=exg:Filter(c19261966.ffilter2,nil,c)
 	if chkf~=PLAYER_NONE then
 		return (g3:IsExists(aux.FConditionFilterF2,1,nil,g2)
 			or g3:IsExists(aux.FConditionFilterF2,1,nil,exg2)
@@ -93,6 +93,7 @@ function c19261966.fuscon(e,g,gc,chkf)
 end
 function c19261966.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 	local fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+	local c=e:GetHandler()
 	local exg=Group.CreateGroup()
 	if fc and fc:IsHasEffect(81788994) and fc:IsCanRemoveCounter(tp,0x16,3,REASON_EFFECT) then
 		local sg=Duel.GetMatchingGroup(c19261966.exfilter,tp,0,LOCATION_MZONE,nil,eg)
@@ -102,10 +103,10 @@ function c19261966.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 		local sg1=Group.CreateGroup()
 		local sg2=Group.CreateGroup()
 		if c19261966.ffilter1(gc) then
-			sg1:Merge(eg:Filter(c19261966.ffilter2,gc))
-			sg2:Merge(exg:Filter(c19261966.ffilter2,gc))
+			sg1:Merge(eg:Filter(c19261966.ffilter2,gc,c))
+			sg2:Merge(exg:Filter(c19261966.ffilter2,gc,c))
 		end
-		if c19261966.ffilter2(gc) then
+		if c19261966.ffilter2(gc,c) then
 			sg1:Merge(eg:Filter(c19261966.ffilter1,gc))
 			sg2:Merge(exg:Filter(c19261966.ffilter1,gc))
 		end
@@ -121,7 +122,7 @@ function c19261966.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 		Duel.SetFusionMaterial(g1)
 		return
 	end
-	local sg=eg:Filter(aux.FConditionFilterF2c,nil,c19261966.ffilter1,c19261966.ffilter2)
+	local sg=eg:Filter(c19261966.FConditionFilterF2c,nil,c19261966.ffilter1,c19261966.ffilter2,c)
 	local g1=nil
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
 	if chkf~=PLAYER_NONE then
@@ -131,10 +132,10 @@ function c19261966.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 	local sg1=Group.CreateGroup()
 	local sg2=Group.CreateGroup()
 	if c19261966.ffilter1(tc1) then
-		sg1:Merge(sg:Filter(c19261966.ffilter2,tc1))
-		sg2:Merge(exg:Filter(c19261966.ffilter2,tc1))
+		sg1:Merge(sg:Filter(c19261966.ffilter2,tc1,c))
+		sg2:Merge(exg:Filter(c19261966.ffilter2,tc1,c))
 	end
-	if c19261966.ffilter2(tc1) then
+	if c19261966.ffilter2(tc1,c) then
 		sg1:Merge(sg:Filter(c19261966.ffilter1,tc1))
 		sg2:Merge(exg:Filter(c19261966.ffilter1,tc1))
 	end
@@ -149,6 +150,9 @@ function c19261966.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 	end
 	g1:Merge(g2)
 	Duel.SetFusionMaterial(g1)
+end
+function c19261966.FConditionFilterF2c(c,f1,f2,fc)
+	return f1(c) or f2(c,fc)
 end
 function c19261966.splimit(e,se,sp,st)
 	return bit.band(st,SUMMON_TYPE_FUSION)==SUMMON_TYPE_FUSION

--- a/script/c20366274.lua
+++ b/script/c20366274.lua
@@ -49,14 +49,13 @@ function c20366274.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 function c20366274.ffilter1(c)
-	return c:IsFusionSetCard(0x9d)
+	return c:IsFusionSetCard(0x9d) and not c:IsHasEffect(6205579) end
 end
-function c20366274.ffilter2(c)
-	--return c:IsAttribute(ATTRIBUTE_LIGHT) or c:IsHasEffect(4904633)
+function c20366274.ffilter2(c,fc)
 	if Card.IsFusionAttribute then
-		return c:IsFusionAttribute(ATTRIBUTE_LIGHT) or c:IsHasEffect(4904633)
+		return (c:IsFusionAttribute(ATTRIBUTE_LIGHT,fc) or c:IsHasEffect(4904633)) and not c:IsHasEffect(6205579)
 	else
-		return c:IsAttribute(ATTRIBUTE_LIGHT) or c:IsHasEffect(4904633)
+		return (c:IsAttribute(ATTRIBUTE_LIGHT) or c:IsHasEffect(4904633)) and not c:IsHasEffect(6205579)
 	end
 end
 function c20366274.exfilter(c,g)
@@ -64,6 +63,7 @@ function c20366274.exfilter(c,g)
 end
 function c20366274.fuscon(e,g,gc,chkf)
 	if g==nil then return true end
+	local c=e:GetHandler()
 	local tp=e:GetHandlerPlayer()
 	local fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
 	local exg=Group.CreateGroup()
@@ -71,8 +71,8 @@ function c20366274.fuscon(e,g,gc,chkf)
 		local sg=Duel.GetMatchingGroup(c20366274.exfilter,tp,0,LOCATION_MZONE,nil,g)
 		exg:Merge(sg)
 	end
-	if gc then return (c20366274.ffilter1(gc) and (g:IsExists(c20366274.ffilter2,1,gc) or exg:IsExists(c20366274.ffilter2,1,gc)))
-		or (c20366274.ffilter2(gc) and (g:IsExists(c20366274.ffilter1,1,gc) or exg:IsExists(c20366274.ffilter1,1,gc))) end
+	if gc then return (c20366274.ffilter1(gc) and (g:IsExists(c20366274.ffilter2,1,gc,c) or exg:IsExists(c20366274.ffilter2,1,gc,c)))
+		or (c20366274.ffilter2(gc,c) and (g:IsExists(c20366274.ffilter1,1,gc) or exg:IsExists(c20366274.ffilter1,1,gc))) end
 	local g1=Group.CreateGroup()
 	local g2=Group.CreateGroup()
 	local g3=Group.CreateGroup()
@@ -83,14 +83,14 @@ function c20366274.fuscon(e,g,gc,chkf)
 			g1:AddCard(tc)
 			if aux.FConditionCheckF(tc,chkf) then g3:AddCard(tc) end
 		end
-		if c20366274.ffilter2(tc) then
+		if c20366274.ffilter2(tc,c) then
 			g2:AddCard(tc)
 			if aux.FConditionCheckF(tc,chkf) then g4:AddCard(tc) end
 		end
 		tc=g:GetNext()
 	end
 	local exg1=exg:Filter(c20366274.ffilter1,nil)
-	local exg2=exg:Filter(c20366274.ffilter2,nil)
+	local exg2=exg:Filter(c20366274.ffilter2,nil,c)
 	if chkf~=PLAYER_NONE then
 		return (g3:IsExists(aux.FConditionFilterF2,1,nil,g2)
 			or g3:IsExists(aux.FConditionFilterF2,1,nil,exg2)
@@ -104,6 +104,7 @@ function c20366274.fuscon(e,g,gc,chkf)
 end
 function c20366274.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 	local fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+	local c=e:GetHandler()
 	local exg=Group.CreateGroup()
 	if fc and fc:IsHasEffect(81788994) and fc:IsCanRemoveCounter(tp,0x16,3,REASON_EFFECT) then
 		local sg=Duel.GetMatchingGroup(c20366274.exfilter,tp,0,LOCATION_MZONE,nil,eg)
@@ -113,10 +114,10 @@ function c20366274.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 		local sg1=Group.CreateGroup()
 		local sg2=Group.CreateGroup()
 		if c20366274.ffilter1(gc) then
-			sg1:Merge(eg:Filter(c20366274.ffilter2,gc))
-			sg2:Merge(exg:Filter(c20366274.ffilter2,gc))
+			sg1:Merge(eg:Filter(c20366274.ffilter2,gc,c))
+			sg2:Merge(exg:Filter(c20366274.ffilter2,gc,c))
 		end
-		if c20366274.ffilter2(gc) then
+		if c20366274.ffilter2(gc,c) then
 			sg1:Merge(eg:Filter(c20366274.ffilter1,gc))
 			sg2:Merge(exg:Filter(c20366274.ffilter1,gc))
 		end
@@ -132,7 +133,7 @@ function c20366274.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 		Duel.SetFusionMaterial(g1)
 		return
 	end
-	local sg=eg:Filter(aux.FConditionFilterF2c,nil,c20366274.ffilter1,c20366274.ffilter2)
+	local sg=eg:Filter(c20366274.FConditionFilterF2c,nil,c20366274.ffilter1,c20366274.ffilter2,c)
 	local g1=nil
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
 	if chkf~=PLAYER_NONE then
@@ -142,10 +143,10 @@ function c20366274.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 	local sg1=Group.CreateGroup()
 	local sg2=Group.CreateGroup()
 	if c20366274.ffilter1(tc1) then
-		sg1:Merge(sg:Filter(c20366274.ffilter2,tc1))
-		sg2:Merge(exg:Filter(c20366274.ffilter2,tc1))
+		sg1:Merge(sg:Filter(c20366274.ffilter2,tc1,c))
+		sg2:Merge(exg:Filter(c20366274.ffilter2,tc1,c))
 	end
-	if c20366274.ffilter2(tc1) then
+	if c20366274.ffilter2(tc1,c) then
 		sg1:Merge(sg:Filter(c20366274.ffilter1,tc1))
 		sg2:Merge(exg:Filter(c20366274.ffilter1,tc1))
 	end
@@ -160,6 +161,9 @@ function c20366274.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 	end
 	g1:Merge(g2)
 	Duel.SetFusionMaterial(g1)
+end
+function c20366274.FConditionFilterF2c(c,f1,f2,fc)
+	return f1(c) or f2(c,fc)
 end
 function c20366274.splimit(e,se,sp,st)
 	return bit.band(st,SUMMON_TYPE_FUSION)==SUMMON_TYPE_FUSION

--- a/script/c22061412.lua
+++ b/script/c22061412.lua
@@ -3,7 +3,7 @@ function c22061412.initial_effect(c)
 	--fusion material
 	c:EnableReviveLimit()
 	if Card.IsFusionAttribute then
-		aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsFusionSetCard,0x3008),aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_LIGHT),true)
+		aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsFusionSetCard,0x3008),aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_LIGHT,c),true)
 	else
 		aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsFusionSetCard,0x3008),aux.FilterBoolFunction(Card.IsAttribute,ATTRIBUTE_LIGHT),true)
 	end

--- a/script/c25586143.lua
+++ b/script/c25586143.lua
@@ -5,7 +5,7 @@ function c25586143.initial_effect(c)
 	--fusion material
 	c:EnableReviveLimit()
 	if Card.IsFusionAttribute then
-		aux.AddFusionProcFun2(c,c25586143.ffilter,aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_DARK),true)
+		aux.AddFusionProcFun2(c,c25586143.ffilter,aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_DARK,c),true)
 	else
 		aux.AddFusionProcFun2(c,c25586143.ffilter,aux.FilterBoolFunction(Card.IsAttribute,ATTRIBUTE_DARK),true)
 	end

--- a/script/c3113836.lua
+++ b/script/c3113836.lua
@@ -3,7 +3,7 @@ function c3113836.initial_effect(c)
 	--fusion material
 	c:EnableReviveLimit()
 	if Card.IsFusionAttribute then
-		aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsFusionSetCard,0x1047),aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_LIGHT),false)
+		aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsFusionSetCard,0x1047),aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_LIGHT,c),false)
 	else
 		aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsFusionSetCard,0x1047),aux.FilterBoolFunction(Card.IsAttribute,ATTRIBUTE_LIGHT),false)
 	end

--- a/script/c33574806.lua
+++ b/script/c33574806.lua
@@ -3,7 +3,7 @@ function c33574806.initial_effect(c)
 	--fusion material
 	c:EnableReviveLimit()
 	if Card.IsFusionAttribute then
-		aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsFusionSetCard,0x3008),aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_DARK),true)
+		aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsFusionSetCard,0x3008),aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_DARK,c),true)
 	else
 		aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsFusionSetCard,0x3008),aux.FilterBoolFunction(Card.IsAttribute,ATTRIBUTE_DARK),true)
 	end

--- a/script/c3642509.lua
+++ b/script/c3642509.lua
@@ -3,7 +3,7 @@ function c3642509.initial_effect(c)
 	--fusion material
 	c:EnableReviveLimit()
 	if Card.IsFusionAttribute then
-		aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsFusionSetCard,0x3008),aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_WIND),true)
+		aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsFusionSetCard,0x3008),aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_WIND,c),true)
 	else
 		aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsFusionSetCard,0x3008),aux.FilterBoolFunction(Card.IsAttribute,ATTRIBUTE_WIND),true)
 	end

--- a/script/c40854197.lua
+++ b/script/c40854197.lua
@@ -3,7 +3,7 @@ function c40854197.initial_effect(c)
 	--fusion material
 	c:EnableReviveLimit()
 	if Card.IsFusionAttribute then
-		aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsFusionSetCard,0x8),aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_WATER),true)
+		aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsFusionSetCard,0x8),aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_WATER,c),true)
 	else
 		aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsFusionSetCard,0x8),aux.FilterBoolFunction(Card.IsAttribute,ATTRIBUTE_WATER),true)
 	end

--- a/script/c41209828.lua
+++ b/script/c41209828.lua
@@ -1,0 +1,163 @@
+--スターヴ・ヴェノム・フュージョン・ドラゴン
+function c41209827.initial_effect(c)
+	--fusion material
+	--aux.AddFusionProcFunRep(c,c41209827.ffilter,2,false)
+	c:EnableReviveLimit()
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_SINGLE)
+	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e0:SetCode(EFFECT_FUSION_MATERIAL)
+	e0:SetCondition(c41209827.funcon)
+	e0:SetOperation(c41209827.funop)
+	c:RegisterEffect(e0)
+	--atk up
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(41209827,0))
+	e1:SetCategory(CATEGORY_ATKCHANGE)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_DELAY)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetCondition(c41209827.atkcon)
+	e1:SetTarget(c41209827.atktg)
+	e1:SetOperation(c41209827.atkop)
+	c:RegisterEffect(e1)
+	--copy
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(41209827,1))
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1)
+	e2:SetCost(c41209827.copycost)
+	e2:SetTarget(c41209827.copytg)
+	e2:SetOperation(c41209827.copyop)
+	c:RegisterEffect(e2)
+	--destroy
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(41209827,2))
+	e3:SetCategory(CATEGORY_DESTROY)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e3:SetProperty(EFFECT_FLAG_DELAY)
+	e3:SetCode(EVENT_DESTROYED)
+	e3:SetCondition(c41209827.descon)
+	e3:SetTarget(c41209827.destg)
+	e3:SetOperation(c41209827.desop)
+	c:RegisterEffect(e3)
+end
+function c41209827.ffilter(c,fc)
+	if Card.IsFusionAttribute then
+		return c:IsFusionAttribute(ATTRIBUTE_DARK,fc) and c:IsLocation(LOCATION_MZONE) and not c:IsType(TYPE_TOKEN)
+	else
+		return c:IsAttribute(ATTRIBUTE_DARK) and c:IsLocation(LOCATION_MZONE) and not c:IsType(TYPE_TOKEN)
+	end
+end
+function c41209827.funcon(e,g,gc,chkfnf)
+	if g==nil then return false end
+	local c=e:GetHandler()
+	local chkf=bit.band(chkfnf,0xff)
+	local mg=g:Filter(Card.IsCanBeFusionMaterial,nil,e:GetHandler())
+	if gc then
+		if not gc:IsCanBeFusionMaterial(e:GetHandler()) then return false end
+		return c41209827.ffilter(gc,c) and mg:IsExists(c41209827.ffilter,1,gc,c) end
+	local g1=mg:Filter(c41209827.ffilter,nil,c)
+	if chkf~=PLAYER_NONE then
+		return g1:FilterCount(Card.IsOnField,nil)~=0 and g1:GetCount()>=2
+	else return g1:GetCount()>=2 end
+end
+function c41209827.funop(e,tp,eg,ep,ev,re,r,rp,gc,chkfnf)
+	local chkf=bit.band(chkfnf,0xff)
+	local c=e:GetHandler()
+	local g=eg:Filter(Card.IsCanBeFusionMaterial,nil,e:GetHandler())
+	if gc then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
+		local g1=g:FilterSelect(tp,c41209827.ffilter,1,1,gc,c)
+		Duel.SetFusionMaterial(g1)
+		return
+	end
+	local sg=g:Filter(c41209827.ffilter,nil,c)
+	if chkf==PLAYER_NONE or sg:GetCount()==2 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
+		local g1=sg:Select(tp,2,2,nil)
+		Duel.SetFusionMaterial(g1)
+		return
+	end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
+	local g1=sg:FilterSelect(tp,Auxiliary.FConditionCheckF,1,1,nil,chkf)
+	if 2>1 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
+		local g2=sg:Select(tp,2-1,2-1,g1:GetFirst())
+		g1:Merge(g2)
+	end
+	Duel.SetFusionMaterial(g1)
+end
+
+function c41209827.atkcon(e,tp,eg,ep,ev,re,r,rp)
+	return bit.band(e:GetHandler():GetSummonType(),SUMMON_TYPE_FUSION)==SUMMON_TYPE_FUSION
+end
+function c41209827.atkfilter(c)
+	return bit.band(c:GetSummonType(),SUMMON_TYPE_SPECIAL)==SUMMON_TYPE_SPECIAL and c:IsFaceup()
+end
+function c41209827.atktg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c41209827.atkfilter,tp,0,LOCATION_MZONE,1,nil) end
+end
+function c41209827.atkop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	local g=Duel.SelectMatchingCard(tp,c41209827.atkfilter,tp,0,LOCATION_MZONE,1,1,nil)
+	local tc=g:GetFirst()
+	if tc and c:IsRelateToEffect(e) and c:IsFaceup() then
+		local atk=tc:GetAttack()
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(atk)
+		e1:SetReset(RESET_EVENT+0x1ff0000+RESET_PHASE+PHASE_END)
+		c:RegisterEffect(e1)
+	end
+end
+function c41209827.copycost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():GetFlagEffect(41209827)==0 end
+	e:GetHandler():RegisterFlagEffect(41209827,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c41209827.copyfilter(c)
+	return c:IsFaceup() and c:IsLevelAbove(5)
+end
+function c41209827.copytg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(1-tp) and chkc:IsLocation(LOCATION_MZONE) and c41209827.copyfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c41209827.copyfilter,tp,0,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	Duel.SelectTarget(tp,c41209827.copyfilter,tp,0,LOCATION_MZONE,1,1,nil)
+end
+function c41209827.copyop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc and c:IsRelateToEffect(e) and c:IsFaceup() and tc:IsRelateToEffect(e) and tc:IsFaceup() and not tc:IsType(TYPE_TOKEN) then
+		local code=tc:GetOriginalCodeRule()
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e1:SetCode(EFFECT_CHANGE_CODE)
+		e1:SetValue(code)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		c:RegisterEffect(e1)
+		if not tc:IsType(TYPE_TRAPMONSTER) then
+			c:CopyEffect(code,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,1)
+		end
+	end
+end
+function c41209827.descon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:IsPreviousLocation(LOCATION_MZONE) and bit.band(c:GetSummonType(),SUMMON_TYPE_FUSION)==SUMMON_TYPE_FUSION
+end
+function c41209827.desfilter(c)
+	return bit.band(c:GetSummonType(),SUMMON_TYPE_SPECIAL)==SUMMON_TYPE_SPECIAL
+end
+function c41209827.destg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c41209827.desfilter,tp,0,LOCATION_MZONE,1,nil) end
+	local g=Duel.GetMatchingGroup(c41209827.desfilter,tp,0,LOCATION_MZONE,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
+end
+function c41209827.desop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(c41209827.desfilter,tp,0,LOCATION_MZONE,nil)
+	Duel.Destroy(g,REASON_EFFECT)
+end

--- a/script/c458748.lua
+++ b/script/c458748.lua
@@ -44,6 +44,8 @@ function c458748.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=g:GetFirst()
 	if tc then
 		tc:SetMaterial(nil)
-		Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
+		if Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)~=0 then
+			tc:CompleteProcedure()
+		end
 	end
 end

--- a/script/c48424886.lua
+++ b/script/c48424886.lua
@@ -41,13 +41,13 @@ function c48424886.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function c48424886.ffilter1(c)
-	return c:IsFusionSetCard(0x9d)
+	return c:IsFusionSetCard(0x9d) and not c:IsHasEffect(6205579) end
 end
-function c48424886.ffilter2(c)
+function c48424886.ffilter2(c,fc)
 	if Card.IsFusionAttribute then
-		return c:IsFusionAttribute(ATTRIBUTE_FIRE) or c:IsHasEffect(4904633)
+		return (c:IsFusionAttribute(ATTRIBUTE_FIRE,fc) or c:IsHasEffect(4904633)) and not c:IsHasEffect(6205579)
 	else
-		return c:IsAttribute(ATTRIBUTE_FIRE) or c:IsHasEffect(4904633)
+		return (c:IsAttribute(ATTRIBUTE_FIRE) or c:IsHasEffect(4904633)) and not c:IsHasEffect(6205579)
 	end
 end
 function c48424886.exfilter(c,g)
@@ -55,6 +55,7 @@ function c48424886.exfilter(c,g)
 end
 function c48424886.fuscon(e,g,gc,chkf)
 	if g==nil then return true end
+	local c=e:GetHandler()
 	local tp=e:GetHandlerPlayer()
 	local fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
 	local exg=Group.CreateGroup()
@@ -62,8 +63,8 @@ function c48424886.fuscon(e,g,gc,chkf)
 		local sg=Duel.GetMatchingGroup(c48424886.exfilter,tp,0,LOCATION_MZONE,nil,g)
 		exg:Merge(sg)
 	end
-	if gc then return (c48424886.ffilter1(gc) and (g:IsExists(c48424886.ffilter2,1,gc) or exg:IsExists(c48424886.ffilter2,1,gc)))
-		or (c48424886.ffilter2(gc) and (g:IsExists(c48424886.ffilter1,1,gc) or exg:IsExists(c48424886.ffilter1,1,gc))) end
+	if gc then return (c48424886.ffilter1(gc) and (g:IsExists(c48424886.ffilter2,1,gc,c) or exg:IsExists(c48424886.ffilter2,1,gc,c)))
+		or (c48424886.ffilter2(gc,c) and (g:IsExists(c48424886.ffilter1,1,gc) or exg:IsExists(c48424886.ffilter1,1,gc))) end
 	local g1=Group.CreateGroup()
 	local g2=Group.CreateGroup()
 	local g3=Group.CreateGroup()
@@ -74,14 +75,14 @@ function c48424886.fuscon(e,g,gc,chkf)
 			g1:AddCard(tc)
 			if aux.FConditionCheckF(tc,chkf) then g3:AddCard(tc) end
 		end
-		if c48424886.ffilter2(tc) then
+		if c48424886.ffilter2(tc,c) then
 			g2:AddCard(tc)
 			if aux.FConditionCheckF(tc,chkf) then g4:AddCard(tc) end
 		end
 		tc=g:GetNext()
 	end
 	local exg1=exg:Filter(c48424886.ffilter1,nil)
-	local exg2=exg:Filter(c48424886.ffilter2,nil)
+	local exg2=exg:Filter(c48424886.ffilter2,nil,c)
 	if chkf~=PLAYER_NONE then
 		return (g3:IsExists(aux.FConditionFilterF2,1,nil,g2)
 			or g3:IsExists(aux.FConditionFilterF2,1,nil,exg2)
@@ -95,6 +96,7 @@ function c48424886.fuscon(e,g,gc,chkf)
 end
 function c48424886.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 	local fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+	local c=e:GetHandler()
 	local exg=Group.CreateGroup()
 	if fc and fc:IsHasEffect(81788994) and fc:IsCanRemoveCounter(tp,0x16,3,REASON_EFFECT) then
 		local sg=Duel.GetMatchingGroup(c48424886.exfilter,tp,0,LOCATION_MZONE,nil,eg)
@@ -104,10 +106,10 @@ function c48424886.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 		local sg1=Group.CreateGroup()
 		local sg2=Group.CreateGroup()
 		if c48424886.ffilter1(gc) then
-			sg1:Merge(eg:Filter(c48424886.ffilter2,gc))
-			sg2:Merge(exg:Filter(c48424886.ffilter2,gc))
+			sg1:Merge(eg:Filter(c48424886.ffilter2,gc,c))
+			sg2:Merge(exg:Filter(c48424886.ffilter2,gc,c))
 		end
-		if c48424886.ffilter2(gc) then
+		if c48424886.ffilter2(gc,c) then
 			sg1:Merge(eg:Filter(c48424886.ffilter1,gc))
 			sg2:Merge(exg:Filter(c48424886.ffilter1,gc))
 		end
@@ -123,7 +125,7 @@ function c48424886.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 		Duel.SetFusionMaterial(g1)
 		return
 	end
-	local sg=eg:Filter(aux.FConditionFilterF2c,nil,c48424886.ffilter1,c48424886.ffilter2)
+	local sg=eg:Filter(c48424886.FConditionFilterF2c,nil,c48424886.ffilter1,c48424886.ffilter2,c)
 	local g1=nil
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
 	if chkf~=PLAYER_NONE then
@@ -133,10 +135,10 @@ function c48424886.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 	local sg1=Group.CreateGroup()
 	local sg2=Group.CreateGroup()
 	if c48424886.ffilter1(tc1) then
-		sg1:Merge(sg:Filter(c48424886.ffilter2,tc1))
-		sg2:Merge(exg:Filter(c48424886.ffilter2,tc1))
+		sg1:Merge(sg:Filter(c48424886.ffilter2,tc1,c))
+		sg2:Merge(exg:Filter(c48424886.ffilter2,tc1,c))
 	end
-	if c48424886.ffilter2(tc1) then
+	if c48424886.ffilter2(tc1,c) then
 		sg1:Merge(sg:Filter(c48424886.ffilter1,tc1))
 		sg2:Merge(exg:Filter(c48424886.ffilter1,tc1))
 	end
@@ -151,6 +153,9 @@ function c48424886.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 	end
 	g1:Merge(g2)
 	Duel.SetFusionMaterial(g1)
+end
+function c48424886.FConditionFilterF2c(c,f1,f2,fc)
+	return f1(c) or f2(c,fc)
 end
 function c48424886.splimit(e,se,sp,st)
 	return bit.band(st,SUMMON_TYPE_FUSION)==SUMMON_TYPE_FUSION

--- a/script/c48791583.lua
+++ b/script/c48791583.lua
@@ -4,7 +4,7 @@
 function c48791583.initial_effect(c)
 	c:EnableReviveLimit()
 	if Card.IsFusionAttribute then
-		aux.AddFusionProcCodeFun(c,86120751,aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_EARTH),1,true,true)
+		aux.AddFusionProcCodeFun(c,86120751,aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_EARTH,c),1,true,true)
 	else
 		aux.AddFusionProcCodeFun(c,86120751,aux.FilterBoolFunction(Card.IsAttribute,ATTRIBUTE_EARTH),1,true,true)
 	end

--- a/script/c49513164.lua
+++ b/script/c49513164.lua
@@ -4,7 +4,7 @@
 function c49513164.initial_effect(c)
 	c:EnableReviveLimit()
 	if Card.IsFusionAttribute then
-		aux.AddFusionProcCodeFun(c,86120751,aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_WIND),1,true,true)
+		aux.AddFusionProcCodeFun(c,86120751,aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_WIND,c),1,true,true)
 	else
 		aux.AddFusionProcCodeFun(c,86120751,aux.FilterBoolFunction(Card.IsAttribute,ATTRIBUTE_WIND),1,true,true)
 	end

--- a/script/c511009368.lua
+++ b/script/c511009368.lua
@@ -2,8 +2,15 @@
 --Fixed by TheOnePharaoh
 function c511009368.initial_effect(c)
 	--fusion material
+	--aux.AddFusionProcFun2(c,c511009368.mat_fil,aux.FilterBoolFunction(Card.IsFusionSetCard,0x9f),true)
 	c:EnableReviveLimit()
-	aux.AddFusionProcFun2(c,c511009368.mat_fil,aux.FilterBoolFunction(Card.IsFusionSetCard,0x9f),true)
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_SINGLE)
+	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e0:SetCode(EFFECT_FUSION_MATERIAL)
+	e0:SetCondition(c511009368.funcon)
+	e0:SetOperation(c511009368.funop)
+	c:RegisterEffect(e0)
 	--damage
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(29343734,0))
@@ -34,13 +41,75 @@ function c511009368.initial_effect(c)
 	e3:SetOperation(c511009368.operation)
 	c:RegisterEffect(e3)
 end
-function c511009368.mat_fil(c)
+function c511009368.mat_fil(c,fc)
 	local attr=c:IsAttribute(ATTRIBUTE_DARK)
 	if Card.IsFusionAttribute then
-		attr=c:IsFusionAttribute(ATTRIBUTE_DARK)
+		attr=c:IsFusionAttribute(ATTRIBUTE_DARK,fc)
 	end
 	return attr and c:GetLevel()>=5
 end
+function c511009368.funcon(e,g,gc,chkfnf)
+	if g==nil then return true end
+	local c=e:GetHandler()
+	local f2=aux.FilterBoolFunction(Card.IsFusionSetCard,0x9f)
+	local chkf=bit.band(chkfnf,0xff)
+	local mg=g:Filter(Card.IsCanBeFusionMaterial,nil,e:GetHandler())
+	if gc then
+		if not gc:IsCanBeFusionMaterial(e:GetHandler()) then return false end
+		return (c511009368.mat_fil(gc,c) and mg:IsExists(f2,1,gc))
+			or (f2(gc) and mg:IsExists(c511009368.mat_fil,1,gc,c)) end
+	local g1=Group.CreateGroup() local g2=Group.CreateGroup() local fs=false
+	local tc=mg:GetFirst()
+	while tc do
+		if c511009368.mat_fil(tc,c) then g1:AddCard(tc) if Auxiliary.FConditionCheckF(tc,chkf) then fs=true end end
+		if f2(tc) then g2:AddCard(tc) if Auxiliary.FConditionCheckF(tc,chkf) then fs=true end end
+		tc=mg:GetNext()
+	end
+	if chkf~=PLAYER_NONE then
+		return fs and g1:IsExists(Auxiliary.FConditionFilterF2,1,nil,g2)
+	else return g1:IsExists(Auxiliary.FConditionFilterF2,1,nil,g2) end
+end
+function c511009368.funop(e,tp,eg,ep,ev,re,r,rp,gc,chkfnf)
+	local chkf=bit.band(chkfnf,0xff)
+	local c=e:GetHandler()
+	local f2=aux.FilterBoolFunction(Card.IsFusionSetCard,0x9f)
+	local g=eg:Filter(Card.IsCanBeFusionMaterial,nil,e:GetHandler())
+	if gc then
+		local sg=Group.CreateGroup()
+		if c511009368.mat_fil(gc,c) then sg:Merge(g:Filter(f2,gc)) end
+		if f2(gc) then sg:Merge(g:Filter(c511009368.mat_fil,gc)) end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
+		local g1=sg:Select(tp,1,1,nil)
+		Duel.SetFusionMaterial(g1)
+		return
+	end
+	local sg=g:Filter(c511009368.FConditionFilterF2c,nil,c)
+	local g1=nil
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
+	if chkf~=PLAYER_NONE then
+		g1=sg:FilterSelect(tp,Auxiliary.FConditionCheckF,1,1,nil,chkf)
+	else g1=sg:Select(tp,1,1,nil) end
+	local tc1=g1:GetFirst()
+	sg:RemoveCard(tc1)
+	local b1=c511009368.mat_fil(tc1)
+	local b2=f2(tc1)
+	if b1 and not b2 then sg:Remove(c511009368.FConditionFilterF2r1,nil,c) end
+	if b2 and not b1 then sg:Remove(c511009368.FConditionFilterF2r2,nil,c) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
+	local g2=sg:Select(tp,1,1,nil)
+	g1:Merge(g2)
+	Duel.SetFusionMaterial(g1)
+end
+function c511009368.FConditionFilterF2c(c,fc)
+	return c511009368.mat_fil(c,fc) or c:IsFusionSetCard(0x9f)
+end
+function c511009368.FConditionFilterF2r1(c,fc)
+	return c511009368.mat_fil(c,fc) and not c:IsFusionSetCard(0x9f)
+end
+function c511009368.FConditionFilterF2r2(c,fc)
+	return c:IsFusionSetCard(0x9f) and not c511009368.mat_fil(c,fc)
+end
+
 function c511009368.damcon(e,tp,eg,ep,ev,re,r,rp)
 	return bit.band(e:GetHandler():GetSummonType(),SUMMON_TYPE_FUSION)==SUMMON_TYPE_FUSION
 end

--- a/script/c51570882.lua
+++ b/script/c51570882.lua
@@ -3,8 +3,15 @@
 --Scripted by Eerie Code
 function c51570882.initial_effect(c)
 	--
+	--aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsFusionSetCard,0x10f3),c51570882.mat_fil,true)
 	c:EnableReviveLimit()
-	aux.AddFusionProcFun2(c,aux.FilterBoolFunction(Card.IsFusionSetCard,0x10f3),c51570882.mat_fil,true)
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_SINGLE)
+	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e0:SetCode(EFFECT_FUSION_MATERIAL)
+	e0:SetCondition(c51570882.funcon)
+	e0:SetOperation(c51570882.funop)
+	c:RegisterEffect(e0)
 	--Must first be Fusion Summoned
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
@@ -36,12 +43,73 @@ function c51570882.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 
-function c51570882.mat_fil(c)
+function c51570882.mat_fil(c,fc)
 	local attr=c:IsAttribute(ATTRIBUTE_DARK)
 	if Card.IsFusionAttribute then
-		attr=c:IsFusionAttribute(ATTRIBUTE_DARK)
+		attr=c:IsFusionAttribute(ATTRIBUTE_DARK,fc)
 	end
 	return attr and c:GetOriginalLevel()>=8
+end
+function c51570882.funcon(e,g,gc,chkfnf)
+	if g==nil then return true end
+	local c=e:GetHandler()
+	local f2=aux.FilterBoolFunction(Card.IsFusionSetCard,0x10f3)
+	local chkf=bit.band(chkfnf,0xff)
+	local mg=g:Filter(Card.IsCanBeFusionMaterial,nil,e:GetHandler())
+	if gc then
+		if not gc:IsCanBeFusionMaterial(e:GetHandler()) then return false end
+		return (c51570882.mat_fil(gc,c) and mg:IsExists(f2,1,gc))
+			or (f2(gc) and mg:IsExists(c51570882.mat_fil,1,gc,c)) end
+	local g1=Group.CreateGroup() local g2=Group.CreateGroup() local fs=false
+	local tc=mg:GetFirst()
+	while tc do
+		if c51570882.mat_fil(tc,c) then g1:AddCard(tc) if Auxiliary.FConditionCheckF(tc,chkf) then fs=true end end
+		if f2(tc) then g2:AddCard(tc) if Auxiliary.FConditionCheckF(tc,chkf) then fs=true end end
+		tc=mg:GetNext()
+	end
+	if chkf~=PLAYER_NONE then
+		return fs and g1:IsExists(Auxiliary.FConditionFilterF2,1,nil,g2)
+	else return g1:IsExists(Auxiliary.FConditionFilterF2,1,nil,g2) end
+end
+function c51570882.funop(e,tp,eg,ep,ev,re,r,rp,gc,chkfnf)
+	local chkf=bit.band(chkfnf,0xff)
+	local c=e:GetHandler()
+	local f2=aux.FilterBoolFunction(Card.IsFusionSetCard,0x10f3)
+	local g=eg:Filter(Card.IsCanBeFusionMaterial,nil,e:GetHandler())
+	if gc then
+		local sg=Group.CreateGroup()
+		if c51570882.mat_fil(gc,c) then sg:Merge(g:Filter(f2,gc)) end
+		if f2(gc) then sg:Merge(g:Filter(c51570882.mat_fil,gc)) end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
+		local g1=sg:Select(tp,1,1,nil)
+		Duel.SetFusionMaterial(g1)
+		return
+	end
+	local sg=g:Filter(c51570882.FConditionFilterF2c,nil,c)
+	local g1=nil
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
+	if chkf~=PLAYER_NONE then
+		g1=sg:FilterSelect(tp,Auxiliary.FConditionCheckF,1,1,nil,chkf)
+	else g1=sg:Select(tp,1,1,nil) end
+	local tc1=g1:GetFirst()
+	sg:RemoveCard(tc1)
+	local b1=c51570882.mat_fil(tc1)
+	local b2=f2(tc1)
+	if b1 and not b2 then sg:Remove(c51570882.FConditionFilterF2r1,nil,c) end
+	if b2 and not b1 then sg:Remove(c51570882.FConditionFilterF2r2,nil,c) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
+	local g2=sg:Select(tp,1,1,nil)
+	g1:Merge(g2)
+	Duel.SetFusionMaterial(g1)
+end
+function c51570882.FConditionFilterF2c(c,fc)
+	return c51570882.mat_fil(c,fc) or c:IsFusionSetCard(0x10f3)
+end
+function c51570882.FConditionFilterF2r1(c,fc)
+	return c51570882.mat_fil(c,fc) and not c:IsFusionSetCard(0x10f3)
+end
+function c51570882.FConditionFilterF2r2(c,fc)
+	return c:IsFusionSetCard(0x10f3) and not c51570882.mat_fil(c,fc)
 end
 
 function c51570882.splimit(e,se,sp,st)

--- a/script/c6205579.lua
+++ b/script/c6205579.lua
@@ -175,18 +175,6 @@ end
 --Adjustment for cards with particular procedures
 function c6205579.adjust(e,tp,eg,ep,ev,re,r,rp)
 	local mt
-	--エルシャドール・アノマリリス (El Shaddoll Anoyatyllis)
-	if c19261966 then
-		mt=c19261966
-		mt.ffilter1=function(c) return c:IsFusionSetCard(0x9d) and not c:IsHasEffect(6205579) end
-		mt.ffilter2=c6205579.elshad_filter(ATTRIBUTE_WATER)
-	end
-	--エルシャドール・ネフィリム (El Shaddoll Construct)
-	if c20366274 then
-		mt=c20366274
-		mt.ffilter1=function(c) return c:IsFusionSetCard(0x9d) and not c:IsHasEffect(6205579) end
-		mt.ffilter2=c6205579.elshad_filter(ATTRIBUTE_LIGHT)
-	end
 	--メタルフォーゼ・オリハルク (Metalfoes Orichalc)
 	if c28016193 then
 		mt=c28016193
@@ -197,34 +185,16 @@ function c6205579.adjust(e,tp,eg,ep,ev,re,r,rp)
 		mt=c4688231
 		mt.filter1=function(c) return c:IsFusionSetCard(0xe1) and not c:IsHasEffect(6205579) end
 	end
-	--エルシャドール・エグリスタ (El Shaddoll Grysta)
-	if c48424886 then
-		mt=c48424886
-		mt.ffilter1=function(c) return c:IsFusionSetCard(0x9d) and not c:IsHasEffect(6205579) end
-		mt.ffilter2=c6205579.elshad_filter(ATTRIBUTE_FIRE)
-	end
 	--メタルフォーゼ・カーディナル (Metalfoes Crimsonite)
 	if c54401832 then
 		mt=c54401832
 		mt.filter1=function(c) return c:IsFusionSetCard(0xe1) and not c:IsHasEffect(6205579) end
 		mt.filter2=function(c) return c:IsAttackBelow(3000) and not c:IsHasEffect(6205579) end
 	end
-	--エルシャドール・ウェンディゴ (El Shaddoll Wendigo)
-	if c74009824 then
-		mt=c74009824
-		mt.ffilter1=function(c) return c:IsFusionSetCard(0x9d) and not c:IsHasEffect(6205579) end
-		mt.ffilter2=c6205579.elshad_filter(ATTRIBUTE_WIND)
-	end
 	--ワーム・ゼロ (Worm Zero)
 	if c74506079 then
 		mt=c74506079
 		mt.ffilter=function(c) return c:IsFusionSetCard(0x3e) and c:IsRace(RACE_REPTILE) and not c:IsHasEffect(6205579) end
-	end
-	--エルシャドール・シェキナーガ (El Shaddoll Shekhinaga)
-	if c74822425 then
-		mt=c74822425
-		mt.ffilter1=function(c) return c:IsFusionSetCard(0x9d) and not c:IsHasEffect(6205579) end
-		mt.ffilter2=c6205579.elshad_filter(ATTRIBUTE_EARTH)
 	end
 	--フルメタルフォーゼ・アルカエスト (Fullmetalfoes Alkahest)
 	if c77693536 then
@@ -241,21 +211,5 @@ function c6205579.adjust(e,tp,eg,ep,ev,re,r,rp)
 	if c84058253 then
 		mt=c84058253
 		mt.ffilter=function(c) return c:IsFusionSetCard(0x1093) and not c:IsHasEffect(6205579) end
-	end
-	--エルシャドール・ミドラーシュ (El Shaddoll Winda)
-	if c94977269 then
-		mt=c94977269
-		mt.ffilter1=function(c) return c:IsFusionSetCard(0x9d) and not c:IsHasEffect(6205579) end
-		mt.ffilter2=c6205579.elshad_filter(ATTRIBUTE_DARK)
-	end
-end
---Material filter for El Shaddoll monsters
-function c6205579.elshad_filter(attr)
-	return function(c)
-		if Card.IsFusionAttribute then
-			return (c:IsFusionAttribute(attr) or c:IsHasEffect(4904633)) and not c:IsHasEffect(6205579)
-		else
-			return (c:IsAttribute(attr) or c:IsHasEffect(4904633)) and not c:IsHasEffect(6205579)
-		end
 	end
 end

--- a/script/c74009824.lua
+++ b/script/c74009824.lua
@@ -40,13 +40,13 @@ function c74009824.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function c74009824.ffilter1(c)
-	return c:IsFusionSetCard(0x9d)
+	return c:IsFusionSetCard(0x9d) and not c:IsHasEffect(6205579)
 end
-function c74009824.ffilter2(c)
+function c74009824.ffilter2(c,fc)
 	if Card.IsFusionAttribute then
-		return c:IsFusionAttribute(ATTRIBUTE_WIND) or c:IsHasEffect(4904633)
+		return (c:IsFusionAttribute(ATTRIBUTE_WIND,fc) or c:IsHasEffect(4904633)) and not c:IsHasEffect(6205579)
 	else
-		return c:IsAttribute(ATTRIBUTE_WIND) or c:IsHasEffect(4904633)
+		return (c:IsAttribute(ATTRIBUTE_WIND) or c:IsHasEffect(4904633)) and not c:IsHasEffect(6205579)
 	end
 end
 function c74009824.exfilter(c,g)
@@ -54,6 +54,7 @@ function c74009824.exfilter(c,g)
 end
 function c74009824.fuscon(e,g,gc,chkf)
 	if g==nil then return true end
+	local c=e:GetHandler()
 	local tp=e:GetHandlerPlayer()
 	local fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
 	local exg=Group.CreateGroup()
@@ -61,8 +62,8 @@ function c74009824.fuscon(e,g,gc,chkf)
 		local sg=Duel.GetMatchingGroup(c74009824.exfilter,tp,0,LOCATION_MZONE,nil,g)
 		exg:Merge(sg)
 	end
-	if gc then return (c74009824.ffilter1(gc) and (g:IsExists(c74009824.ffilter2,1,gc) or exg:IsExists(c74009824.ffilter2,1,gc)))
-		or (c74009824.ffilter2(gc) and (g:IsExists(c74009824.ffilter1,1,gc) or exg:IsExists(c74009824.ffilter1,1,gc))) end
+	if gc then return (c74009824.ffilter1(gc) and (g:IsExists(c74009824.ffilter2,1,gc,c) or exg:IsExists(c74009824.ffilter2,1,gc,c)))
+		or (c74009824.ffilter2(gc,c) and (g:IsExists(c74009824.ffilter1,1,gc) or exg:IsExists(c74009824.ffilter1,1,gc))) end
 	local g1=Group.CreateGroup()
 	local g2=Group.CreateGroup()
 	local g3=Group.CreateGroup()
@@ -73,14 +74,14 @@ function c74009824.fuscon(e,g,gc,chkf)
 			g1:AddCard(tc)
 			if aux.FConditionCheckF(tc,chkf) then g3:AddCard(tc) end
 		end
-		if c74009824.ffilter2(tc) then
+		if c74009824.ffilter2(tc,c) then
 			g2:AddCard(tc)
 			if aux.FConditionCheckF(tc,chkf) then g4:AddCard(tc) end
 		end
 		tc=g:GetNext()
 	end
 	local exg1=exg:Filter(c74009824.ffilter1,nil)
-	local exg2=exg:Filter(c74009824.ffilter2,nil)
+	local exg2=exg:Filter(c74009824.ffilter2,nil,c)
 	if chkf~=PLAYER_NONE then
 		return (g3:IsExists(aux.FConditionFilterF2,1,nil,g2)
 			or g3:IsExists(aux.FConditionFilterF2,1,nil,exg2)
@@ -94,6 +95,7 @@ function c74009824.fuscon(e,g,gc,chkf)
 end
 function c74009824.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 	local fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+	local c=e:GetHandler()
 	local exg=Group.CreateGroup()
 	if fc and fc:IsHasEffect(81788994) and fc:IsCanRemoveCounter(tp,0x16,3,REASON_EFFECT) then
 		local sg=Duel.GetMatchingGroup(c74009824.exfilter,tp,0,LOCATION_MZONE,nil,eg)
@@ -103,10 +105,10 @@ function c74009824.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 		local sg1=Group.CreateGroup()
 		local sg2=Group.CreateGroup()
 		if c74009824.ffilter1(gc) then
-			sg1:Merge(eg:Filter(c74009824.ffilter2,gc))
-			sg2:Merge(exg:Filter(c74009824.ffilter2,gc))
+			sg1:Merge(eg:Filter(c74009824.ffilter2,gc,c))
+			sg2:Merge(exg:Filter(c74009824.ffilter2,gc,c))
 		end
-		if c74009824.ffilter2(gc) then
+		if c74009824.ffilter2(gc,c) then
 			sg1:Merge(eg:Filter(c74009824.ffilter1,gc))
 			sg2:Merge(exg:Filter(c74009824.ffilter1,gc))
 		end
@@ -122,7 +124,7 @@ function c74009824.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 		Duel.SetFusionMaterial(g1)
 		return
 	end
-	local sg=eg:Filter(aux.FConditionFilterF2c,nil,c74009824.ffilter1,c74009824.ffilter2)
+	local sg=eg:Filter(c74009824.FConditionFilterF2c,nil,c74009824.ffilter1,c74009824.ffilter2,c)
 	local g1=nil
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
 	if chkf~=PLAYER_NONE then
@@ -132,10 +134,10 @@ function c74009824.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 	local sg1=Group.CreateGroup()
 	local sg2=Group.CreateGroup()
 	if c74009824.ffilter1(tc1) then
-		sg1:Merge(sg:Filter(c74009824.ffilter2,tc1))
-		sg2:Merge(exg:Filter(c74009824.ffilter2,tc1))
+		sg1:Merge(sg:Filter(c74009824.ffilter2,tc1,c))
+		sg2:Merge(exg:Filter(c74009824.ffilter2,tc1,c))
 	end
-	if c74009824.ffilter2(tc1) then
+	if c74009824.ffilter2(tc1,c) then
 		sg1:Merge(sg:Filter(c74009824.ffilter1,tc1))
 		sg2:Merge(exg:Filter(c74009824.ffilter1,tc1))
 	end
@@ -150,6 +152,9 @@ function c74009824.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 	end
 	g1:Merge(g2)
 	Duel.SetFusionMaterial(g1)
+end
+function c74009824.FConditionFilterF2c(c,f1,f2,fc)
+	return f1(c) or f2(c,fc)
 end
 function c74009824.splimit(e,se,sp,st)
 	return bit.band(st,SUMMON_TYPE_FUSION)==SUMMON_TYPE_FUSION

--- a/script/c74822425.lua
+++ b/script/c74822425.lua
@@ -42,13 +42,13 @@ function c74822425.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function c74822425.ffilter1(c)
-	return c:IsFusionSetCard(0x9d)
+	return c:IsFusionSetCard(0x9d) and not c:IsHasEffect(6205579) end
 end
-function c74822425.ffilter2(c)
+function c74822425.ffilter2(c,fc)
 	if Card.IsFusionAttribute then
-		return c:IsFusionAttribute(ATTRIBUTE_EARTH) or c:IsHasEffect(4904633)
+		return (c:IsFusionAttribute(ATTRIBUTE_EARTH,fc) or c:IsHasEffect(4904633)) and not c:IsHasEffect(6205579)
 	else
-		return c:IsAttribute(ATTRIBUTE_EARTH) or c:IsHasEffect(4904633)
+		return (c:IsAttribute(ATTRIBUTE_EARTH) or c:IsHasEffect(4904633)) and not c:IsHasEffect(6205579)
 	end
 end
 function c74822425.exfilter(c,g)
@@ -56,6 +56,7 @@ function c74822425.exfilter(c,g)
 end
 function c74822425.fuscon(e,g,gc,chkf)
 	if g==nil then return true end
+	local c=e:GetHandler()
 	local tp=e:GetHandlerPlayer()
 	local fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
 	local exg=Group.CreateGroup()
@@ -63,8 +64,8 @@ function c74822425.fuscon(e,g,gc,chkf)
 		local sg=Duel.GetMatchingGroup(c74822425.exfilter,tp,0,LOCATION_MZONE,nil,g)
 		exg:Merge(sg)
 	end
-	if gc then return (c74822425.ffilter1(gc) and (g:IsExists(c74822425.ffilter2,1,gc) or exg:IsExists(c74822425.ffilter2,1,gc)))
-		or (c74822425.ffilter2(gc) and (g:IsExists(c74822425.ffilter1,1,gc) or exg:IsExists(c74822425.ffilter1,1,gc))) end
+	if gc then return (c74822425.ffilter1(gc) and (g:IsExists(c74822425.ffilter2,1,gc,c) or exg:IsExists(c74822425.ffilter2,1,gc,c)))
+		or (c74822425.ffilter2(gc,c) and (g:IsExists(c74822425.ffilter1,1,gc) or exg:IsExists(c74822425.ffilter1,1,gc))) end
 	local g1=Group.CreateGroup()
 	local g2=Group.CreateGroup()
 	local g3=Group.CreateGroup()
@@ -75,14 +76,14 @@ function c74822425.fuscon(e,g,gc,chkf)
 			g1:AddCard(tc)
 			if aux.FConditionCheckF(tc,chkf) then g3:AddCard(tc) end
 		end
-		if c74822425.ffilter2(tc) then
+		if c74822425.ffilter2(tc,c) then
 			g2:AddCard(tc)
 			if aux.FConditionCheckF(tc,chkf) then g4:AddCard(tc) end
 		end
 		tc=g:GetNext()
 	end
 	local exg1=exg:Filter(c74822425.ffilter1,nil)
-	local exg2=exg:Filter(c74822425.ffilter2,nil)
+	local exg2=exg:Filter(c74822425.ffilter2,nil,c)
 	if chkf~=PLAYER_NONE then
 		return (g3:IsExists(aux.FConditionFilterF2,1,nil,g2)
 			or g3:IsExists(aux.FConditionFilterF2,1,nil,exg2)
@@ -96,6 +97,7 @@ function c74822425.fuscon(e,g,gc,chkf)
 end
 function c74822425.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 	local fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+	local c=e:GetHandler()
 	local exg=Group.CreateGroup()
 	if fc and fc:IsHasEffect(81788994) and fc:IsCanRemoveCounter(tp,0x16,3,REASON_EFFECT) then
 		local sg=Duel.GetMatchingGroup(c74822425.exfilter,tp,0,LOCATION_MZONE,nil,eg)
@@ -105,10 +107,10 @@ function c74822425.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 		local sg1=Group.CreateGroup()
 		local sg2=Group.CreateGroup()
 		if c74822425.ffilter1(gc) then
-			sg1:Merge(eg:Filter(c74822425.ffilter2,gc))
-			sg2:Merge(exg:Filter(c74822425.ffilter2,gc))
+			sg1:Merge(eg:Filter(c74822425.ffilter2,gc,c))
+			sg2:Merge(exg:Filter(c74822425.ffilter2,gc,c))
 		end
-		if c74822425.ffilter2(gc) then
+		if c74822425.ffilter2(gc,c) then
 			sg1:Merge(eg:Filter(c74822425.ffilter1,gc))
 			sg2:Merge(exg:Filter(c74822425.ffilter1,gc))
 		end
@@ -124,7 +126,7 @@ function c74822425.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 		Duel.SetFusionMaterial(g1)
 		return
 	end
-	local sg=eg:Filter(aux.FConditionFilterF2c,nil,c74822425.ffilter1,c74822425.ffilter2)
+	local sg=eg:Filter(c74822425.FConditionFilterF2c,nil,c74822425.ffilter1,c74822425.ffilter2,c)
 	local g1=nil
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
 	if chkf~=PLAYER_NONE then
@@ -134,10 +136,10 @@ function c74822425.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 	local sg1=Group.CreateGroup()
 	local sg2=Group.CreateGroup()
 	if c74822425.ffilter1(tc1) then
-		sg1:Merge(sg:Filter(c74822425.ffilter2,tc1))
-		sg2:Merge(exg:Filter(c74822425.ffilter2,tc1))
+		sg1:Merge(sg:Filter(c74822425.ffilter2,tc1,c))
+		sg2:Merge(exg:Filter(c74822425.ffilter2,tc1,c))
 	end
-	if c74822425.ffilter2(tc1) then
+	if c74822425.ffilter2(tc1,c) then
 		sg1:Merge(sg:Filter(c74822425.ffilter1,tc1))
 		sg2:Merge(exg:Filter(c74822425.ffilter1,tc1))
 	end
@@ -152,6 +154,9 @@ function c74822425.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 	end
 	g1:Merge(g2)
 	Duel.SetFusionMaterial(g1)
+end
+function c74822425.FConditionFilterF2c(c,f1,f2,fc)
+	return f1(c) or f2(c,fc)
 end
 function c74822425.splimit(e,se,sp,st)
 	return bit.band(st,SUMMON_TYPE_FUSION)==SUMMON_TYPE_FUSION

--- a/script/c75286621.lua
+++ b/script/c75286621.lua
@@ -4,7 +4,7 @@
 function c75286621.initial_effect(c)
 	c:EnableReviveLimit()
 	if Card.IsFusionAttribute then
-		aux.AddFusionProcCodeFun(c,86120751,aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_LIGHT),1,true,true)
+		aux.AddFusionProcCodeFun(c,86120751,aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_LIGHT,c),1,true,true)
 	else
 		aux.AddFusionProcCodeFun(c,86120751,aux.FilterBoolFunction(Card.IsAttribute,ATTRIBUTE_LIGHT),1,true,true)
 	end

--- a/script/c85908279.lua
+++ b/script/c85908279.lua
@@ -4,7 +4,7 @@
 function c85908279.initial_effect(c)
 	c:EnableReviveLimit()
 	if Card.IsFusionAttribute then
-		aux.AddFusionProcCodeFun(c,86120751,aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_WATER),1,true,true)
+		aux.AddFusionProcCodeFun(c,86120751,aux.FilterBoolFunction(Card.IsFusionAttribute,ATTRIBUTE_WATER,c),1,true,true)
 	else
 		aux.AddFusionProcCodeFun(c,86120751,aux.FilterBoolFunction(Card.IsAttribute,ATTRIBUTE_WATER),1,true,true)
 	end

--- a/script/c89181134.lua
+++ b/script/c89181134.lua
@@ -3,6 +3,14 @@
 --Scripted by Eerie Code
 function c89181134.initial_effect(c)
 	--fusattribute
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_FIELD)
+	e0:SetCode(0x10000000)
+	e0:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e0:SetRange(LOCATION_MZONE)
+	e0:SetTargetRange(1,0)
+	c:RegisterEffect(e0)
+	--
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
 	if EFFECT_CHANGE_FUSION_ATTRIBUTE then
@@ -26,14 +34,18 @@ function c89181134.initial_effect(c)
 	e2:SetOperation(c89181134.operation)
 	c:RegisterEffect(e2)
 	if not Card.IsFusionAttribute then
-		function Card.IsFusionAttribute(c,att)
-			local att2=0x01
-			while att2<ATTRIBUTE_DEVINE do
-				local a=att2+0x10000000
-				if c:IsHasEffect(a) then
-					return bit.band(att,att2)==att
-				else
-					att2=att2*2
+		function Card.IsFusionAttribute(c,att,fc)
+			local tp=fc:GetControler()
+			local gc=Duel.IsPlayerAffectedByEffect(tp,0x10000000)
+			if gc then
+				local att2=0x01
+				while att2<ATTRIBUTE_DEVINE do
+					local a=att2+0x10000000
+					if c:IsHasEffect(a) then
+						return bit.band(att,att2)==att
+					else
+						att2=att2*2
+					end
 				end
 			end
 			return c:IsAttribute(att)

--- a/script/c94977269.lua
+++ b/script/c94977269.lua
@@ -47,13 +47,13 @@ function c94977269.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 function c94977269.ffilter1(c)
-	return c:IsFusionSetCard(0x9d)
+	return c:IsFusionSetCard(0x9d) and not c:IsHasEffect(6205579) end
 end
-function c94977269.ffilter2(c)
+function c94977269.ffilter2(c,fc)
 	if Card.IsFusionAttribute then
-		return c:IsFusionAttribute(ATTRIBUTE_DARK) or c:IsHasEffect(4904633)
+		return (c:IsFusionAttribute(ATTRIBUTE_DARK,fc) or c:IsHasEffect(4904633)) and not c:IsHasEffect(6205579)
 	else
-		return c:IsAttribute(ATTRIBUTE_DARK) or c:IsHasEffect(4904633)
+		return (c:IsAttribute(ATTRIBUTE_DARK) or c:IsHasEffect(4904633)) and not c:IsHasEffect(6205579)
 	end
 end
 function c94977269.exfilter(c,g)
@@ -61,6 +61,7 @@ function c94977269.exfilter(c,g)
 end
 function c94977269.fuscon(e,g,gc,chkf)
 	if g==nil then return true end
+	local c=e:GetHandler()
 	local tp=e:GetHandlerPlayer()
 	local fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
 	local exg=Group.CreateGroup()
@@ -68,8 +69,8 @@ function c94977269.fuscon(e,g,gc,chkf)
 		local sg=Duel.GetMatchingGroup(c94977269.exfilter,tp,0,LOCATION_MZONE,nil,g)
 		exg:Merge(sg)
 	end
-	if gc then return (c94977269.ffilter1(gc) and (g:IsExists(c94977269.ffilter2,1,gc) or exg:IsExists(c94977269.ffilter2,1,gc)))
-		or (c94977269.ffilter2(gc) and (g:IsExists(c94977269.ffilter1,1,gc) or exg:IsExists(c94977269.ffilter1,1,gc))) end
+	if gc then return (c94977269.ffilter1(gc) and (g:IsExists(c94977269.ffilter2,1,gc,c) or exg:IsExists(c94977269.ffilter2,1,gc,c)))
+		or (c94977269.ffilter2(gc,c) and (g:IsExists(c94977269.ffilter1,1,gc) or exg:IsExists(c94977269.ffilter1,1,gc))) end
 	local g1=Group.CreateGroup()
 	local g2=Group.CreateGroup()
 	local g3=Group.CreateGroup()
@@ -80,14 +81,14 @@ function c94977269.fuscon(e,g,gc,chkf)
 			g1:AddCard(tc)
 			if aux.FConditionCheckF(tc,chkf) then g3:AddCard(tc) end
 		end
-		if c94977269.ffilter2(tc) then
+		if c94977269.ffilter2(tc,c) then
 			g2:AddCard(tc)
 			if aux.FConditionCheckF(tc,chkf) then g4:AddCard(tc) end
 		end
 		tc=g:GetNext()
 	end
 	local exg1=exg:Filter(c94977269.ffilter1,nil)
-	local exg2=exg:Filter(c94977269.ffilter2,nil)
+	local exg2=exg:Filter(c94977269.ffilter2,nil,c)
 	if chkf~=PLAYER_NONE then
 		return (g3:IsExists(aux.FConditionFilterF2,1,nil,g2)
 			or g3:IsExists(aux.FConditionFilterF2,1,nil,exg2)
@@ -101,6 +102,7 @@ function c94977269.fuscon(e,g,gc,chkf)
 end
 function c94977269.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 	local fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+	local c=e:GetHandler()
 	local exg=Group.CreateGroup()
 	if fc and fc:IsHasEffect(81788994) and fc:IsCanRemoveCounter(tp,0x16,3,REASON_EFFECT) then
 		local sg=Duel.GetMatchingGroup(c94977269.exfilter,tp,0,LOCATION_MZONE,nil,eg)
@@ -110,10 +112,10 @@ function c94977269.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 		local sg1=Group.CreateGroup()
 		local sg2=Group.CreateGroup()
 		if c94977269.ffilter1(gc) then
-			sg1:Merge(eg:Filter(c94977269.ffilter2,gc))
-			sg2:Merge(exg:Filter(c94977269.ffilter2,gc))
+			sg1:Merge(eg:Filter(c94977269.ffilter2,gc,c))
+			sg2:Merge(exg:Filter(c94977269.ffilter2,gc,c))
 		end
-		if c94977269.ffilter2(gc) then
+		if c94977269.ffilter2(gc,c) then
 			sg1:Merge(eg:Filter(c94977269.ffilter1,gc))
 			sg2:Merge(exg:Filter(c94977269.ffilter1,gc))
 		end
@@ -129,7 +131,7 @@ function c94977269.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 		Duel.SetFusionMaterial(g1)
 		return
 	end
-	local sg=eg:Filter(aux.FConditionFilterF2c,nil,c94977269.ffilter1,c94977269.ffilter2)
+	local sg=eg:Filter(c94977269.FConditionFilterF2c,nil,c94977269.ffilter1,c94977269.ffilter2,c)
 	local g1=nil
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FMATERIAL)
 	if chkf~=PLAYER_NONE then
@@ -139,10 +141,10 @@ function c94977269.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 	local sg1=Group.CreateGroup()
 	local sg2=Group.CreateGroup()
 	if c94977269.ffilter1(tc1) then
-		sg1:Merge(sg:Filter(c94977269.ffilter2,tc1))
-		sg2:Merge(exg:Filter(c94977269.ffilter2,tc1))
+		sg1:Merge(sg:Filter(c94977269.ffilter2,tc1,c))
+		sg2:Merge(exg:Filter(c94977269.ffilter2,tc1,c))
 	end
-	if c94977269.ffilter2(tc1) then
+	if c94977269.ffilter2(tc1,c) then
 		sg1:Merge(sg:Filter(c94977269.ffilter1,tc1))
 		sg2:Merge(exg:Filter(c94977269.ffilter1,tc1))
 	end
@@ -157,6 +159,9 @@ function c94977269.fusop(e,tp,eg,ep,ev,re,r,rp,gc,chkf)
 	end
 	g1:Merge(g2)
 	Duel.SetFusionMaterial(g1)
+end
+function c94977269.FConditionFilterF2c(c,f1,f2,fc)
+	return f1(c) or f2(c,fc)
 end
 function c94977269.splimit(e,se,sp,st)
 	return bit.band(st,SUMMON_TYPE_FUSION)==SUMMON_TYPE_FUSION


### PR DESCRIPTION
The complete Card.IsFusionAttribute() procedure now also takes as a parameter the Fusion Monster summonable using the monster you're checking the attribute of: since you can only Fusion Summon monsters in your Extra Deck, this lets you figure out the player who is performing the Fusion Summon. From that, the procedure determines whether the player is affected by Sundew's effect, and depending on that checks the attribute as before. All old cards have been updated to reflect this addition, with the summon procedure of "Starving Venom Fusion Dragon", "Greedy Venom Fusion Dragon" and "Performapal Gatling Ghoul" having been rewritten by necessity. These changes have already been tested, all cards appear to work as intended.