### PR TITLE
anime card fix

### DIFF
--- a/c511009133.lua
+++ b/c511009133.lua
@@ -1,0 +1,54 @@
+--Cipher Interfere
+function c511009133.initial_effect(c)
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	c:RegisterEffect(e1)
+	
+	--atkup
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetCode(EVENT_FREE_CHAIN)
+	e2:SetHintTiming(TIMING_DAMAGE_STEP)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
+	e2:SetCondition(c511009133.atkcon)
+	e2:SetCountLimit(1)
+	e2:SetTarget(c511009133.atktg)
+	e2:SetOperation(c511009133.atkop)
+	c:RegisterEffect(e2)
+end
+function c511009133.filter(c,code)
+	return c:IsFaceup() and c:IsCode(code)
+end
+function c511009133.atkcon(e,tp,eg,ep,ev,re,r,rp)
+	local phase=Duel.GetCurrentPhase()
+	if Duel.IsDamageCalculated() then return false end
+	local tc=Duel.GetAttacker()
+	if not tc then return false end
+	if tc:IsControler(1-tp) then 
+	tc=Duel.GetAttackTarget() 
+	end
+	e:SetLabelObject(tc)
+	return tc and tc:IsFaceup() and tc:IsSetCard(0xe5) and tc:IsRelateToBattle()  and d:IsRelateToBattle() 
+	and Duel.IsExistingMatchingCard(c511009133.filter,0,LOCATION_MZONE,LOCATION_MZONE,1,tc,tc:GetCode())
+		and not e:GetHandler():IsStatus(STATUS_CHAINING)
+end
+function c511009133.atktg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tc=e:GetLabelObject()
+	if chkc then return chkc==tc end
+	if chk==0 then return tc and tc:IsOnField() and tc:IsCanBeEffectTarget(e) end
+	Duel.SetTargetCard(tc)
+end
+function c511009133.atkop(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if not c:IsRelateToEffect(e) or not tc or not tc:IsRelateToBattle() or tc:IsFacedown() then return end
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_SET_ATTACK_FINAL)
+	e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_BATTLE)
+	e1:SetValue(tc:GetAttack()*2)
+	tc:RegisterEffect(e1)
+end
+

--- a/c511009373.lua
+++ b/c511009373.lua
@@ -1,0 +1,81 @@
+--Illegal Dark Contract with the War God
+function c511009373.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	c:RegisterEffect(e1)
+	--unaffected
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(511000809,0))
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetCode(EVENT_FREE_CHAIN)
+	e2:SetCountLimit(1)
+	e2:SetCategory(CATEGORY_ATKCHANGE)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCondition(c511009373.condition)
+	e2:SetTarget(c511009373.target)
+	e2:SetOperation(c511009373.operation)
+	c:RegisterEffect(e2)
+	-- damage
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(45974017,3))
+	e3:SetCategory(CATEGORY_DAMAGE)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e3:SetRange(LOCATION_SZONE)
+	e3:SetCode(EVENT_PHASE+PHASE_STANDBY)
+	e3:SetCountLimit(1)
+	e3:SetCondition(c511009373.damcon)
+	e3:SetTarget(c511009373.damtg)
+	e3:SetOperation(c511009373.damop)
+	c:RegisterEffect(e3)
+end
+function c511009373.filter(c)
+	return c:IsFaceup() and c:IsSetCard(0xaf)
+end
+function c511009373.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()==PHASE_MAIN1 or Duel.GetCurrentPhase()==PHASE_MAIN2
+end
+function c511009373.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return false end
+	if chk==0 then return Duel.IsExistingTarget(c511009373.filter,tp,LOCATION_MZONE,0,1,nil)
+		and Duel.IsExistingTarget(Card.IsFaceup,tp,0,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	Duel.SelectTarget(tp,c511009373.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	Duel.SelectTarget(tp,Card.IsFaceup,tp,0,LOCATION_MZONE,1,1,nil)
+end
+function c511009373.operation(e,tp,eg,ep,ev,re,r,rp)
+local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
+	local tc1=g:GetFirst()
+	local tc2=g:GetNext()
+	if tc1:IsFaceup() and tc2:IsFaceup() and tc1:IsRelateToEffect(e) and tc2:IsRelateToEffect(e) then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(1000)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_BATTLE)
+		tc1:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(e:GetHandler())
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_UPDATE_ATTACK)
+		e2:SetValue(-1000)
+		e2:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_BATTLE)
+		tc2:RegisterEffect(e2)
+	end
+end
+function c511009373.damcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()==tp
+end
+function c511009373.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(tp)
+	Duel.SetTargetParam(1000)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,0,0,tp,1000)
+end
+function c511009373.damop(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Damage(p,d,REASON_EFFECT)
+end

--- a/c511009383.lua
+++ b/c511009383.lua
@@ -1,0 +1,88 @@
+--D/D Brownie
+function c511009383.initial_effect(c)
+
+	--set
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(66762372,1))
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e2:SetRange(LOCATION_PZONE)
+	e2:SetTarget(c511009383.settg)
+	e2:SetOperation(c511009383.setop)
+	c:RegisterEffect(e2)
+	
+	--
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e3:SetCondition(c511009383.effcon)
+	e3:SetOperation(c511009383.regop)
+	c:RegisterEffect(e3)
+	--
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(17540705,1))
+	e4:SetCategory(CATEGORY_DRAW)
+	e4:SetType(EFFECT_TYPE_IGNITION)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e4:SetCondition(c511009383.sccon)
+	e4:SetCost(c511009383.sccost)
+	e4:SetTarget(c511009383.sctg)
+	e4:SetOperation(c511009383.scop)
+	c:RegisterEffect(e4)
+end
+
+function c511009383.cfilter(c,tp)
+	return c:IsFaceup() and c:GetSummonLocation()==LOCATION_EXTRA and c:GetPreviousControler()==tp
+end
+function c511009383.setcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(c511009383.cfilter,1,nil,tp)
+end
+function c511009383.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
+end
+function c511009383.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and c:IsRelateToEffect(e) then
+		Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)
+	end
+end
+
+function c511009383.effcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsSummonType(SUMMON_TYPE_PENDULUM) and c:GetSummonLocation()==LOCATION_EXTRA
+end
+function c511009383.regop(e,tp,eg,ep,ev,re,r,rp)
+	e:GetHandler():RegisterFlagEffect(511009383+1,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+end
+
+function c511009383.sccon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetFlagEffect(511009383+1)~=0
+end
+function c511009383.cfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0xaf)
+end
+function c511009383.filter(c)
+	return (c:GetSequence()==6 or c:GetSequence()==7)
+end
+function c511009383.sccost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsReleasable() and Duel.CheckReleaseGroup(tp,c511009383.cfilter,1,nil) end
+	local g=Duel.SelectReleaseGroup(tp,c511009383.cfilter,1,1,nil)
+	g:AddCard(e:GetHandler())
+	Duel.Release(g,REASON_COST)
+end
+function c511009383.sctg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chkc then return chkc:IsLocation(LOCATION_SZONE) and c511009383.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c511009383.filter,tp,LOCATION_SZONE,LOCATION_SZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,c511009383.filter,tp,LOCATION_SZONE,LOCATION_SZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+end
+function c511009383.scop(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
+	end
+end

--- a/c511009392.lua
+++ b/c511009392.lua
@@ -1,0 +1,118 @@
+--D/D/D Knowledge King Tomb Conquistador
+function c511009392.initial_effect(c)
+	--pendulum summon
+	aux.EnablePendulumAttribute(c)
+	-- Peffect
+	--activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetCode(EVENT_CHAINING)
+	e1:SetRange(LOCATION_PZONE)
+	e1:SetCondition(c511009392.damcon)
+	e1:SetOperation(c511009392.damop)
+	c:RegisterEffect(e1)
+	--atkup
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(91596726,0))
+	e2:SetCategory(CATEGORY_ATKCHANGE)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCost(c511009392.cost)
+	e2:SetOperation(c511009392.operation)
+	c:RegisterEffect(e2)
+	--actlimit
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e3:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e3:SetOperation(c511009392.atkop)
+	c:RegisterEffect(e3)
+	--search
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(64973287,1))
+	e3:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e3:SetCode(EVENT_BATTLE_DESTROYING)
+	e3:SetCondition(aux.bdocon)
+	e3:SetTarget(c511009392.target)
+	e3:SetOperation(c511009392.operation)
+	c:RegisterEffect(e3)
+end
+-- REGEN LP
+function c511009392.damcon(e,tp,eg,ep,ev,re,r,rp)
+	if tp~=Duel.GetTurnPlayer() then return false end
+	local ex,cg,ct,cp,cv=Duel.GetOperationInfo(ev,CATEGORY_DAMAGE)
+	if ex and (cp==tp or cp==PLAYER_ALL) then return true end
+	ex,cg,ct,cp,cv=Duel.GetOperationInfo(ev,CATEGORY_RECOVER)
+	return re:IsSetCard(0xae) and ex and (cp==tp or cp==PLAYER_ALL) and Duel.IsPlayerAffectedByEffect(tp,EFFECT_REVERSE_RECOVER)
+end
+function c511009392.damop(e,tp,eg,ep,ev,re,r,rp)
+	local cid=Duel.GetChainInfo(ev,CHAININFO_CHAIN_ID)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_REVERSE_DAMAGE)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetTargetRange(1,0)
+	e1:SetLabel(cid)
+	e1:SetValue(c511009392.refcon)
+	e1:SetReset(RESET_CHAIN)
+	Duel.RegisterEffect(e1,tp)
+end
+function .rec511009392fcon(e,re,r,rp,rc)
+	local cc=Duel.GetCurrentChain()
+	if cc==0 or bit.band(r,REASON_EFFECT)==0 then return end
+	local cid=Duel.GetChainInfo(0,CHAININFO_CHAIN_ID)
+	return cid==e:GetLabel()
+end
+
+
+--ATK UP
+function c511009392.cfilter(c)
+	return c:IsSetCard(0xae) and c:IsAbleToGraveAsCost()
+end
+function c511009392.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c511009392.cfilter,tp,LOCATION_SZONE+LOCATION_HAND,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g=Duel.SelectMatchingCard(tp,c511009392.cfilter,tp,LOCATION_SZONE+LOCATION_HAND,0,1,1,nil)
+	Duel.SendtoGrave(g,REASON_COST)
+end
+function c511009392.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsFaceup() and c:IsRelateToEffect(e) then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(1000)
+		e1:SetReset(RESET_EVENT+0x1ff0000)
+		c:RegisterEffect(e1)
+	end
+end
+
+function c511009392.atkop(e,tp,eg,ep,ev,re,r,rp)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetCode(EFFECT_CANNOT_ACTIVATE)
+	e1:SetTargetRange(0,1)
+	e1:SetValue(c511009392.aclimit)
+	e1:SetReset(RESET_PHASE+PHASE_DAMAGE)
+	Duel.RegisterEffect(e1,tp)
+end
+function c511009392.aclimit(e,re,tp)
+	return re:IsHasType(EFFECT_TYPE_ACTIVATE)
+end
+function c511009392.filter(c)
+	return c:IsSetCard(0xae) and c:IsAbleToHand()
+end
+function c511009392.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c511009392.filter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c511009392.operation(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c511009392.filter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end

--- a/c511009396.lua
+++ b/c511009396.lua
@@ -1,0 +1,50 @@
+--Dark Seed Planter
+function c511009396.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_ATKCHANGE)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c511009396.target)
+	e1:SetOperation(c511009396.activate)
+	c:RegisterEffect(e1)
+	--disable attack
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(84013237,0))
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e1:SetRange(LOCATION_SZONE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c511009396.atkcon)
+	e1:SetOperation(c511009396.atkop)
+	c:RegisterEffect(e1)
+end
+
+function c511009396.filter(c)
+	return c:IsFaceup() and not c:IsAttribute(ATTRIBUTE_DARK)
+end
+function c511009396.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil) end
+end
+function c511009396.activate(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
+	local sg=Duel.GetMatchingGroup(c511009396.filter,tp,0,LOCATION_MZONE,nil)
+	local tc=sg:GetFirst()
+	while tc do
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetRange(LOCATION_MZONE)
+		e1:SetCode(EFFECT_CHANGE_ATTRIBUTE)
+		e1:SetValue(ATTRIBUTE_DARK)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		tc:RegisterEffect(e1)
+		tc=sg:GetNext()
+	end
+end
+function c511009396.atkcon(e,tp,eg,ep,ev,re,r,rp)
+	local atker=Duel.GetAttacker()
+	local atktg=Duel.GetAttackTarget()
+	return atker and atktg and atker:IsFaceup() and atktg:IsFaceup() and atktg:IsControler(tp) and atktg:IsAttribute(ATTRIBUTE_DARK) and atker:IsAttribute(ATTRIBUTE_DARK)
+end
+function c511009396.atkop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.NegateAttack()
+end

--- a/c511009410.lua
+++ b/c511009410.lua
@@ -1,0 +1,104 @@
+--Ivy Bind Castle
+function c511009410.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	c:RegisterEffect(e1)
+	--cannot attack
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_CANNOT_ATTACK)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetTargetRange(0,LOCATION_MZONE)
+	c:RegisterEffect(e2)
+	--disable
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetCode(EFFECT_DISABLE)
+	e3:SetRange(LOCATION_SZONE)
+	e3:SetTargetRange(0,LOCATION_ONFIELD)
+	c:RegisterEffect(e3)
+	--disable effect
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e4:SetCode(EVENT_CHAIN_SOLVING)
+	e4:SetRange(LOCATION_SZONE)
+	e4:SetOperation(c511009410.disop)
+	c:RegisterEffect(e4)
+	--damage
+	local e5=Effect.CreateEffect(c)
+	e5:SetDescription(aux.Stringid(30757396,0))
+	e5:SetCategory(CATEGORY_DAMAGE)
+	e5:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e5:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e5:SetCode(EVENT_PHASE+PHASE_STANDBY)
+	e5:SetRange(LOCATION_SZONE)
+	e5:SetCountLimit(1)
+	e5:SetCondition(c511009410.damcon)
+	e5:SetTarget(c511009410.damtg)
+	e5:SetOperation(c511009410.damop)
+	c:RegisterEffect(e5)
+	
+	--earth
+	local e7=Effect.CreateEffect(c)
+	e7:SetDescription(aux.Stringid(33900648,1))
+	e7:SetCategory(CATEGORY_DESTROY)
+	e7:SetCode(EVENT_PHASE+PHASE_STANDBY)
+	e7:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e7:SetRange(LOCATION_SZONE)
+	e7:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e7:SetCountLimit(1)
+	e7:SetCondition(c511009410.descon)
+	e7:SetTarget(c511009410.destg)
+	e7:SetOperation(c511009410.desop)
+	c:RegisterEffect(e7)
+end
+
+
+function c511009410.disop(e,tp,eg,ep,ev,re,r,rp)
+	local tl=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
+	if rp~=tp and (tl==LOCATION_MZONE or tl==LOCATION_SZONE) then
+		Duel.NegateEffect(ev)
+	end
+end
+
+function c511009410.damcon(e,tp,eg,ep,ev,re,r,rp)
+	return tp~=Duel.GetTurnPlayer()
+end
+function c511009410.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	local ct=Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,ct*800)
+end
+function c511009410.damop(e,tp,eg,ep,ev,re,r,rp)
+	local p=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER)
+	local ct=Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)
+	Duel.Damage(p,ct*800,REASON_EFFECT)
+end
+
+function c511009410.descon(e,tp,eg,ep,ev,re,r,rp)
+	return tp==Duel.GetTurnPlayer()
+end
+function c511009410.desfilter(c)
+	return c:IsSetCard(0x10f3)
+end
+function c511009410.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c511009410.desfilter(chkc) end
+	if chk==0 then return true end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,c511009410.desfilter,tp,LOCATION_MZONE,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+	end
+end
+function c511009410.desop(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) then
+		if Duel.Release(tc,REASON_EFFECT)==0 then 
+			Duel.Destroy(e:GetHandler(), REASON_EFFECT)
+		end
+	end
+end


### PR DESCRIPTION
Fix for the follwing cards:
illegal dard contract with the war god: corrected the atk change
Dark seed planter: you can now activate it if your opponent control only dark monsters
ivy bind castle: fixed the damage part
D/D Brownie: fixed script error
D/D/D conquistador : fixed script error
Cipher interphere: now work with direct atk