### PR TITLE
Anime Card Fixes

### DIFF
--- a/script/c111011904.lua
+++ b/script/c111011904.lua
@@ -91,12 +91,12 @@ function c111011904.operation2(e,tp,eg,ep,ev,re,r,rp,chk)
 				of=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
 				if fc and Duel.Destroy(fc,REASON_RULE)==0 then Duel.SendtoGrave(tc,REASON_RULE) end
 			else
-				Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+				fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
 				if fc and Duel.SendtoGrave(fc,REASON_RULE)==0 then Duel.SendtoGrave(tc,REASON_RULE) end
 			end
 		end
 		Duel.MoveToField(tc,tp,tp,LOCATION_SZONE,POS_FACEUP,true)
-		if bit.band(tpe,TYPE_TRAP+TYPE_FIELD)~=0 then
+		if bit.band(tpe,TYPE_TRAP+TYPE_FIELD)==TYPE_TRAP+TYPE_FIELD then
 			Duel.MoveSequence(tc,5)
 		end
 		Duel.Hint(HINT_CARD,0,tc:GetCode())

--- a/script/c511000056.lua
+++ b/script/c511000056.lua
@@ -21,15 +21,19 @@ function c511000056.spfilter(c,e,tp,code)
 end
 function c511000056.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local nt=Duel.GetMatchingGroup(c511000056.filter2,tp,LOCATION_MZONE,0,nil)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-2
+	local ect=c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-2 and not Duel.IsPlayerAffectedByEffect(tp,59822133) 
+		and (not ect or ect>=2) and Duel.IsExistingMatchingCard(c511000056.filter1,tp,LOCATION_MZONE,0,1,nil,nt) 
 		and Duel.IsExistingMatchingCard(c511000056.spfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp,2403771)
 		and	Duel.IsExistingMatchingCard(c511000056.spfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp,25862681)
-		and Duel.IsExistingMatchingCard(c511000056.filter1,tp,LOCATION_MZONE,0,1,nil,nt)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,2,0,0)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,0,0)
 end
 function c511000056.activate(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=1 or Duel.IsPlayerAffectedByEffect(tp,59822133) then return end
+	local ect=c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]
+	if ect~=nil and ect<2 then return end
 	local nt=Duel.GetMatchingGroup(c511000056.filter2,tp,LOCATION_MZONE,0,nil)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 	local g=Duel.SelectMatchingCard(tp,c511000056.filter1,tp,LOCATION_MZONE,0,1,1,nil,nt)

--- a/script/c511000276.lua
+++ b/script/c511000276.lua
@@ -22,12 +22,15 @@ function c511000276.filter(c,e,tp)
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c511000276.tg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local ect=c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>3 and not Duel.IsPlayerAffectedByEffect(tp,59822133) 
-		and Duel.IsExistingMatchingCard(c511000276.filter,tp,LOCATION_EXTRA,0,4,nil,e,tp) end
+		and Duel.IsExistingMatchingCard(c511000276.filter,tp,LOCATION_EXTRA,0,4,nil,e,tp) and (not ect or ect>=4) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function c511000276.op(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=3 or Duel.IsPlayerAffectedByEffect(tp,59822133) then return end
+	local ect=c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]
+	if ect~=nil and ect<4 then return end
 	local g=Duel.GetMatchingGroup(c511000276.filter,tp,LOCATION_EXTRA,0,nil,e,tp)
 	if g:GetCount()<=3 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)

--- a/script/c511000440.lua
+++ b/script/c511000440.lua
@@ -75,7 +75,7 @@ function c511000440.activate(e,tp,eg,ep,ev,re,r,rp)
 					of=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
 					if fc and Duel.Destroy(fc,REASON_RULE)==0 then Duel.SendtoGrave(tc,REASON_RULE) end
 				else
-					Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+					fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
 					if fc and Duel.SendtoGrave(fc,REASON_RULE)==0 then Duel.SendtoGrave(tc,REASON_RULE) end
 				end
 			end

--- a/script/c511000467.lua
+++ b/script/c511000467.lua
@@ -55,7 +55,7 @@ function c511000467.setop(e,tp,eg,ep,ev,re,r,rp)
 			of=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
 			if fc and Duel.Destroy(fc,REASON_RULE)==0 then Duel.SendtoGrave(tc,REASON_RULE) end
 		else
-			Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+			fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
 			if fc and Duel.SendtoGrave(fc,REASON_RULE)==0 then Duel.SendtoGrave(tc,REASON_RULE) end
 		end
 		Duel.MoveSequence(tc,5)

--- a/script/c511000685.lua
+++ b/script/c511000685.lua
@@ -12,27 +12,33 @@ function c511000685.initial_effect(c)
 end
 function c511000685.filter1(c,e,tp)
 	local rk=c:GetRank()
-	return rk>0 and c:IsFaceup() and Duel.IsExistingMatchingCard(c511000685.filter2,tp,LOCATION_EXTRA,0,2,nil,rk,e,tp)
+	return rk>0 and c:IsFaceup() and Duel.IsExistingMatchingCard(c511000685.filter2,tp,LOCATION_EXTRA,0,2,nil,rk,e,tp,c,c:GetCode())
 		and c:IsCode(84013237) and c:GetOverlayGroup():GetCount()>=2
 end
-function c511000685.filter2(c,rk,e,tp)
-	return (c:GetRank()==rk+1 or c:GetRank()==rk+2) and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_XYZ,tp,false,false)
+function c511000685.filter2(c,rk,e,tp,mc,code)
+	if c:GetOriginalCode()==6165656 and code~=48995978 then return false end
+	return (c:GetRank()==rk+1 or c:GetRank()==rk+2) and mc:IsCanBeXyzMaterial(c) 
+		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_XYZ,tp,false,false)
 end
 function c511000685.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c511000685.filter1(chkc,e,tp) end
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>1
-		and Duel.IsExistingTarget(c511000685.filter1,tp,LOCATION_MZONE,0,1,nil,e,tp) end
+	local ect=c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>1 and not Duel.IsPlayerAffectedByEffect(tp,59822133) 
+		and Duel.IsExistingTarget(c511000685.filter1,tp,LOCATION_MZONE,0,1,nil,e,tp) and (not ect or math.min(ect,2)>=2) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
 	local g=Duel.SelectTarget(tp,c511000685.filter1,tp,LOCATION_MZONE,0,1,1,nil,e,tp)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,tp,LOCATION_EXTRA)
 end
 function c511000685.activate(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetLocationCount(tp,LOCATION_MZONE)<1 then return end
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<1 or Duel.IsPlayerAffectedByEffect(tp,59822133) then return end
+	local ect=c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]
+	if ect~=nil and ect<2 then return end
 	local tc=Duel.GetFirstTarget()
+	if not tc or tc:IsFacedown() or not tc:IsRelateToEffect(e) or tc:IsControler(1-tp) or tc:IsImmuneToEffect(e) then return end
 	local ou=tc:GetOverlayGroup()
-	if tc:IsFacedown() or not tc:IsRelateToEffect(e) or tc:IsControler(1-tp) or tc:IsImmuneToEffect(e) or ou:GetCount()<2 then return end
+	if ou:GetCount()<2 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectMatchingCard(tp,c511000685.filter2,tp,LOCATION_EXTRA,0,2,2,nil,tc:GetRank(),e,tp)
+	local g=Duel.SelectMatchingCard(tp,c511000685.filter2,tp,LOCATION_EXTRA,0,2,2,nil,tc:GetRank(),e,tp,tc,tc:GetCode())
 	if Duel.SpecialSummonStep(g:GetFirst(),SUMMON_TYPE_XYZ,tp,tp,false,false,POS_FACEUP)~=0 and
 		Duel.SpecialSummonStep(g:GetNext(),SUMMON_TYPE_XYZ,tp,tp,false,false,POS_FACEUP)~=0 then
 		Duel.BreakEffect()

--- a/script/c511000786.lua
+++ b/script/c511000786.lua
@@ -54,12 +54,12 @@ function c511000786.activate(e,tp,eg,ep,ev,re,r,rp)
 				of=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
 				if fc and Duel.Destroy(fc,REASON_RULE)==0 then Duel.SendtoGrave(tc,REASON_RULE) end
 			else
-				Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+				fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
 				if fc and Duel.SendtoGrave(fc,REASON_RULE)==0 then Duel.SendtoGrave(tc,REASON_RULE) end
 			end
 		end
 		Duel.MoveToField(tc,tp,tp,LOCATION_SZONE,POS_FACEUP,true)
-		if bit.band(tpe,TYPE_TRAP+TYPE_FIELD)~=0 then
+		if bit.band(tpe,TYPE_TRAP+TYPE_FIELD)==TYPE_TRAP+TYPE_FIELD then
 			Duel.MoveSequence(tc,5)
 		end
 		Duel.Hint(HINT_CARD,0,tc:GetCode())

--- a/script/c511000847.lua
+++ b/script/c511000847.lua
@@ -17,6 +17,22 @@ function c511000847.initial_effect(c)
 	e2:SetTarget(c511000847.drtg)
 	e2:SetOperation(c511000847.drop)
 	c:RegisterEffect(e2)
+	if not c511000847.global_check then
+		c511000847.global_check=true
+		--check obsolete ruling
+		local ge1=Effect.CreateEffect(c)
+		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge1:SetCode(EVENT_DRAW)
+		ge1:SetOperation(c511000847.checkop)
+		Duel.RegisterEffect(ge1,0)
+	end
+end
+function c511000847.checkop(e,tp,eg,ep,ev,re,r,rp)
+	if bit.band(r,REASON_RULE)~=0 and Duel.GetTurnCount()==1 then
+		--obsolete
+		Duel.RegisterFlagEffect(tp,62765383,0,0,1)
+		Duel.RegisterFlagEffect(1-tp,62765383,0,0,1)
+	end
 end
 function c511000847.drcon(e,tp,eg,ep,ev,re,r,rp)
 	return ep~=tp
@@ -46,12 +62,20 @@ function c511000847.drop(e,tp,eg,ep,ev,re,r,rp)
 			e:SetProperty(te:GetProperty())
 			Duel.ClearTargetCard()
 			if bit.band(tpe,TYPE_FIELD)~=0 then
-				local of=Duel.GetFieldCard(1-tp,LOCATION_SZONE,5)
-				if of then Duel.Destroy(of,REASON_RULE) end
-				of=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
-				if of and Duel.Destroy(of,REASON_RULE)==0 then Duel.SendtoGrave(tc,REASON_RULE) end
+				local fc=Duel.GetFieldCard(1-tp,LOCATION_SZONE,5)
+				if Duel.GetFlagEffect(tp,62765383)>0 then
+				if fc then Duel.Destroy(fc,REASON_RULE) end
+					of=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+					if fc and Duel.Destroy(fc,REASON_RULE)==0 then Duel.SendtoGrave(tc,REASON_RULE) end
+				else
+					fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+					if fc and Duel.SendtoGrave(fc,REASON_RULE)==0 then Duel.SendtoGrave(tc,REASON_RULE) end
+				end
 			end
 			Duel.MoveToField(tc,tp,tp,LOCATION_SZONE,POS_FACEUP,true)
+			if bit.band(tpe,TYPE_TRAP+TYPE_FIELD)==TYPE_TRAP+TYPE_FIELD then
+				Duel.MoveSequence(tc,5)
+			end
 			Duel.Hint(HINT_CARD,0,tc:GetCode())
 			tc:CreateEffectRelation(te)
 			if bit.band(tpe,TYPE_EQUIP+TYPE_CONTINUOUS+TYPE_FIELD)==0 then

--- a/script/c511000984.lua
+++ b/script/c511000984.lua
@@ -98,7 +98,7 @@ function c511000984.acop(e,tp,eg,ep,ev,re,r,rp)
 			of=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
 			if fc and Duel.Destroy(fc,REASON_RULE)==0 then Duel.SendtoGrave(tc,REASON_RULE) end
 		else
-			Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+			fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
 			if fc and Duel.SendtoGrave(fc,REASON_RULE)==0 then Duel.SendtoGrave(tc,REASON_RULE) end
 		end
 	end

--- a/script/c511001122.lua
+++ b/script/c511001122.lua
@@ -100,7 +100,7 @@ function c511001122.operation(e,tp,eg,ep,ev,re,r,rp)
 					of=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
 					if fc and Duel.Destroy(fc,REASON_RULE)==0 then Duel.SendtoGrave(tc,REASON_RULE) end
 				else
-					Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+					fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
 					if fc and Duel.SendtoGrave(fc,REASON_RULE)==0 then Duel.SendtoGrave(tc,REASON_RULE) end
 				end
 			end

--- a/script/c511001145.lua
+++ b/script/c511001145.lua
@@ -68,7 +68,7 @@ function c511001145.activate(e,tp,eg,ep,ev,re,r,rp)
 				of=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
 				if fc and Duel.Destroy(fc,REASON_RULE)==0 then Duel.SendtoGrave(tc,REASON_RULE) end
 			else
-				Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+				fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
 				if fc and Duel.SendtoGrave(fc,REASON_RULE)==0 then Duel.SendtoGrave(tc,REASON_RULE) end
 			end
 		end

--- a/script/c511001180.lua
+++ b/script/c511001180.lua
@@ -1,6 +1,6 @@
 --The Greatest Duo of the Seven Emperors
 function c511001180.initial_effect(c)
---Activate
+	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -13,18 +13,21 @@ end
 function c511001180.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	local a=Duel.GetAttacker()
 	local att=Duel.GetAttackTarget()
-	return ep==tp and
-	 (a:IsSetCard(0x1048) or (att and att:IsSetCard(0x1048)))
+	return ep==tp and (a:IsSetCard(0x1048) or (att and att:IsSetCard(0x1048)))
 end
 function c511001180.tgfilter(c,code,e,tp)
 	return c:IsCode(code) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c511001180.tgtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c511001180.tgfilter,tp,LOCATION_EXTRA,0,1,nil,20785975,e,tp)
+	local ect=c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]
+	if chk==0 then return (not ect or ect>=2) and not Duel.IsPlayerAffectedByEffect(tp,59822133) 
+		and Duel.IsExistingMatchingCard(c511001180.tgfilter,tp,LOCATION_EXTRA,0,1,nil,20785975,e,tp)
 		and Duel.IsExistingMatchingCard(c511001180.tgfilter,tp,LOCATION_EXTRA,0,1,nil,67173574,e,tp) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,0,0)
 end
 function c511001180.tgop(e,tp,eg,ep,ev,re,r,rp)
+	local ect=c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) or (ect and ect<2) then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local tc1=Duel.SelectMatchingCard(tp,c511001180.tgfilter,tp,LOCATION_EXTRA,0,1,1,nil,20785975,e,tp):GetFirst()
 	local tc2=Duel.SelectMatchingCard(tp,c511001180.tgfilter,tp,LOCATION_EXTRA,0,1,1,nil,67173574,e,tp):GetFirst()

--- a/script/c511001187.lua
+++ b/script/c511001187.lua
@@ -35,12 +35,15 @@ function c511001187.spfilter(c,e,tp)
 		and no and no>=101 and no<=107 and c:IsSetCard(0x1048) 
 end
 function c511001187.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	local ect=c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>2 and not Duel.IsPlayerAffectedByEffect(tp,59822133) 
-		and Duel.IsExistingMatchingCard(c511001187.spfilter,tp,LOCATION_EXTRA,0,3,nil,e,tp) end
+		and Duel.IsExistingMatchingCard(c511001187.spfilter,tp,LOCATION_EXTRA,0,3,nil,e,tp) and (not ect or ect>=3) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,3,tp,LOCATION_EXTRA)
 end
 function c511001187.activate(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<3 or Duel.IsPlayerAffectedByEffect(tp,59822133) then return end
+	local ect=c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]
+	if ect~=nil and ect<3 then return end
 	local g=Duel.GetMatchingGroup(c511001187.spfilter,tp,LOCATION_EXTRA,0,nil,e,tp)
 	if g:GetCount()<3 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)

--- a/script/c511001271.lua
+++ b/script/c511001271.lua
@@ -44,6 +44,8 @@ function c511001271.operation(e,tp,eg,ep,ev,re,r,rp)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	if ft<=0 then return end
 	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
+	local ect=c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]
+	if ect~=nil then ft=math.min(ft,ect) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,c511001271.spfilter,tp,LOCATION_EXTRA,0,ft,ft,nil,e,tp)
 	if g:GetCount()>0 then

--- a/script/c511001334.lua
+++ b/script/c511001334.lua
@@ -40,48 +40,38 @@ function c511001334.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function c511001334.activate(e,tp,eg,ep,ev,re,r,rp)
-	if true then
-		local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
-		local mg1=Duel.GetMatchingGroup(c511001334.filter1,tp,LOCATION_HAND+LOCATION_MZONE,0,nil,e)
-		local sg1=Duel.GetMatchingGroup(c511001334.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
-		local mg2=nil
-		local sg2=nil
-		local ce=Duel.GetChainMaterial(tp)
-		if ce~=nil then
-			local fgroup=ce:GetTarget()
-			mg2=fgroup(ce,e,tp)
-			local mf=ce:GetValue()
-			sg2=Duel.GetMatchingGroup(c511001334.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg2,mf,chkf)
-		end
+	local ect=c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]
+	local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
+	local mg1=Duel.GetMatchingGroup(c511001334.filter1,tp,LOCATION_HAND+LOCATION_MZONE,0,nil,e)
+	local sg1=Duel.GetMatchingGroup(c511001334.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
+	local mg2=nil
+	local sg2=nil
+	local ce=Duel.GetChainMaterial(tp)
+	if ce~=nil then
+		local fgroup=ce:GetTarget()
+		mg2=fgroup(ce,e,tp)
+		local mf=ce:GetValue()
+		sg2=Duel.GetMatchingGroup(c511001334.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg2,mf,chkf)
+	end
 		if sg1:GetCount()>0 or (sg2~=nil and sg2:GetCount()>0) then
-			local sg=sg1:Clone()
-			if sg2 then sg:Merge(sg2) end
-			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-			local tg=sg:Select(tp,1,1,nil)
-			local tc=tg:GetFirst()
-			if sg1:IsContains(tc) and (sg2==nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp,ce:GetDescription())) then
-				local mat1=Duel.SelectFusionMaterial(tp,tc,mg1,nil,chkf)
-				tc:SetMaterial(mat1)
-				Duel.SendtoGrave(mat1,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
-				Duel.BreakEffect()
-				Duel.SpecialSummonStep(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
-				tc:SetStatus(STATUS_SPSUMMON_STEP,false)
-			else
-				local mat2=Duel.SelectFusionMaterial(tp,tc,mg2,nil,chkf)
-				local fop=ce:GetOperation()
-				fop(ce,e,tp,tc,mat2)
-			end
-			tc:CompleteProcedure()
+		local sg=sg1:Clone()
+		if sg2 then sg:Merge(sg2) end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local tg=sg:Select(tp,1,1,nil)
+		local tc=tg:GetFirst()
+		if sg1:IsContains(tc) and (sg2==nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp,ce:GetDescription())) then
+			local mat1=Duel.SelectFusionMaterial(tp,tc,mg1,nil,chkf)
+			tc:SetMaterial(mat1)
+			Duel.SendtoGrave(mat1,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
+			Duel.BreakEffect()
+			Duel.SpecialSummonStep(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
+			tc:SetStatus(STATUS_SPSUMMON_STEP,false)
 		else
-			local cg1=Duel.GetFieldGroup(tp,LOCATION_HAND+LOCATION_MZONE,0)
-			local cg2=Duel.GetFieldGroup(tp,LOCATION_EXTRA,0)
-			if cg1:GetCount()>1 and cg2:IsExists(Card.IsFacedown,1,nil)
-				and Duel.IsPlayerCanSpecialSummon(tp) and not Duel.IsPlayerAffectedByEffect(tp,27581098) then
-				Duel.ConfirmCards(1-tp,cg1)
-				Duel.ConfirmCards(1-tp,cg2)
-				Duel.ShuffleHand(tp)
-			end
+			local mat2=Duel.SelectFusionMaterial(tp,tc,mg2,nil,chkf)
+			local fop=ce:GetOperation()
+			fop(ce,e,tp,tc,mat2)
 		end
+		tc:CompleteProcedure()
 	end
 	local tchkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
 	local tmg1=Duel.GetMatchingGroup(Card.IsCanBeFusionMaterial,tp,LOCATION_HAND+LOCATION_MZONE,0,nil)
@@ -95,7 +85,7 @@ function c511001334.activate(e,tp,eg,ep,ev,re,r,rp)
 			res=Duel.IsExistingMatchingCard(c511001334.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg2,mf,tchkf)
 		end
 	end
-	if res and not Duel.IsPlayerAffectedByEffect(tp,59822133) and Duel.SelectYesNo(tp,aux.Stringid(33550694,0)) then
+	if res and not Duel.IsPlayerAffectedByEffect(tp,59822133) and (not ect or ect>=2) and Duel.SelectYesNo(tp,aux.Stringid(33550694,0)) then
 		local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
 		local mg1=Duel.GetMatchingGroup(c511001334.filter1,tp,LOCATION_HAND+LOCATION_MZONE,0,nil,e)
 		local sg1=Duel.GetMatchingGroup(c511001334.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
@@ -126,15 +116,6 @@ function c511001334.activate(e,tp,eg,ep,ev,re,r,rp)
 				fop(ce,e,tp,tc,mat2)
 			end
 			tc:CompleteProcedure()
-		else
-			local cg1=Duel.GetFieldGroup(tp,LOCATION_HAND+LOCATION_MZONE,0)
-			local cg2=Duel.GetFieldGroup(tp,LOCATION_EXTRA,0)
-			if cg1:GetCount()>1 and cg2:IsExists(Card.IsFacedown,1,nil)
-				and Duel.IsPlayerCanSpecialSummon(tp) and not Duel.IsPlayerAffectedByEffect(tp,27581098) then
-				Duel.ConfirmCards(1-tp,cg1)
-				Duel.ConfirmCards(1-tp,cg2)
-				Duel.ShuffleHand(tp)
-			end
 		end
 	end
 	Duel.SpecialSummonComplete()

--- a/script/c511001427.lua
+++ b/script/c511001427.lua
@@ -28,9 +28,11 @@ function c511001427.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local tid=Duel.GetTurnCount()
 	local g=Duel.GetMatchingGroup(c511001427.filter,tp,LOCATION_GRAVE,LOCATION_GRAVE,nil,tp,tid)
 	local ct=g:GetCount()
+	local ect=c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]
 	if chk==0 then return ct>0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>=ct and Duel.GetLocationCount(1-tp,LOCATION_MZONE)>=ct 
-		and g:IsExists(Card.IsCanBeSpecialSummoned,ct,nil,e,0,tp,false,false) 
-		and Duel.IsExistingMatchingCard(c511001427.spfilter,tp,LOCATION_EXTRA,0,ct,nil,e,tp) end
+		and g:IsExists(Card.IsCanBeSpecialSummoned,ct,nil,e,0,tp,false,false) and (not ect or ect>=ct) 
+		and Duel.IsExistingMatchingCard(c511001427.spfilter,tp,LOCATION_EXTRA,0,ct,nil,e,tp) 
+		and (not Duel.IsPlayerAffectedByEffect(tp,59822133) or ct<2) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,ct,0,0)
 end
 function c511001427.activate(e,tp,eg,ep,ev,re,r,rp)
@@ -40,6 +42,9 @@ function c511001427.activate(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<ct or Duel.GetLocationCount(1-tp,LOCATION_MZONE)<ct then return end
 	if not Duel.IsExistingMatchingCard(c511001427.spfilter,tp,LOCATION_EXTRA,0,ct,nil,e,tp) then return end
 	if not g:IsExists(Card.IsCanBeSpecialSummoned,ct,nil,e,0,tp,false,false) then return end
+	if ct>1 and Duel.IsPlayerAffectedByEffect(tp,59822133) then return end
+	local ect=c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]
+	if ect~=nil and ct>ect then return end
 	if ct>0 then
 		local tc=g:GetFirst()
 		while tc do

--- a/script/c511001431.lua
+++ b/script/c511001431.lua
@@ -46,13 +46,14 @@ function c511001431.initial_effect(c)
 	end
 end
 c511001431.xyz_number=106
-
 function c511001431.rumfilter(c)
-	return c:IsCode(88177324) and not c:IsPreviousLocation(LOCATION_OVERLAY)
+	return c:IsCode(63746411) and not c:IsPreviousLocation(LOCATION_OVERLAY)
 end
 function c511001431.rankupregcon(e,tp,eg,ep,ev,re,r,rp)
-		local rc=re:GetHandler()
-	return e:GetHandler():IsSummonType(SUMMON_TYPE_XYZ) and (rc:IsSetCard(0x95) or rc:IsCode(100000581) or rc:IsCode(111011002) or rc:IsCode(511000580) or rc:IsCode(511002068) or rc:IsCode(511002164) or rc:IsCode(93238626)) and e:GetHandler():GetMaterial():IsExists(c511001431.rumfilter,1,nil)
+	local rc=re:GetHandler()
+	return e:GetHandler():IsSummonType(SUMMON_TYPE_XYZ) and re 
+		and (rc:IsSetCard(0x95) or rc:IsCode(100000581) or rc:IsCode(111011002) or rc:IsCode(511000580) or rc:IsCode(511002068) or rc:IsCode(511002164) or rc:IsCode(93238626)) 
+		and e:GetHandler():GetMaterial():IsExists(c511001431.rumfilter,1,nil)
 end
 function c511001431.rankupregop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
@@ -62,7 +63,6 @@ function c511001431.rankupregop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetCategory(CATEGORY_DISABLE)
 	e1:SetType(EFFECT_TYPE_IGNITION)
 	e1:SetRange(LOCATION_MZONE)
-	e1:SetCondition(c511001431.discon)
 	e1:SetCost(c511001431.discost)
 	e1:SetTarget(c511001431.distg)
 	e1:SetOperation(c511001431.disop)
@@ -72,9 +72,6 @@ end
 function c511001431.damval(e,re,val,r,rp,rc)
 	if e:GetHandler():IsPosition(POS_FACEUP_ATTACK) and bit.band(r,REASON_EFFECT)~=0 then return 0
 	else return val end
-end
-function c511001431.discon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():GetOverlayGroup():IsExists(Card.IsCode,1,nil,63746411)
 end
 function c511001431.discost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end

--- a/script/c511001499.lua
+++ b/script/c511001499.lua
@@ -7,6 +7,22 @@ function c511001499.initial_effect(c)
 	e1:SetTarget(c511001499.target)
 	e1:SetOperation(c511001499.activate)
 	c:RegisterEffect(e1)
+	if not c511009338.global_check then
+		c511009338.global_check=true
+		--check obsolete ruling
+		local ge1=Effect.CreateEffect(c)
+		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge1:SetCode(EVENT_DRAW)
+		ge1:SetOperation(c511001499.checkop)
+		Duel.RegisterEffect(ge1,0)
+	end
+end
+function c511001499.checkop(e,tp,eg,ep,ev,re,r,rp)
+	if bit.band(r,REASON_RULE)~=0 and Duel.GetTurnCount()==1 then
+		--obsolete
+		Duel.RegisterFlagEffect(tp,62765383,0,0,1)
+		Duel.RegisterFlagEffect(1-tp,62765383,0,0,1)
+	end
 end
 function c511001499.filter(c,tp,eg,ep,ev,re,r,rp)
 	local te=c:GetActivateEffect()
@@ -40,10 +56,20 @@ function c511001499.activate(e,tp,eg,ep,ev,re,r,rp)
 			e:SetCategory(te:GetCategory())
 			e:SetProperty(te:GetProperty())
 			if bit.band(tpe,TYPE_FIELD)~=0 then
-				local of=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
-				if of and Duel.Destroy(of,REASON_RULE)==0 then Duel.SendtoGrave(tc,REASON_RULE) end
+				local fc=Duel.GetFieldCard(1-tp,LOCATION_SZONE,5)
+				if Duel.GetFlagEffect(tp,62765383)>0 then
+					if fc then Duel.Destroy(fc,REASON_RULE) end
+					of=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+					if fc and Duel.Destroy(fc,REASON_RULE)==0 then Duel.SendtoGrave(tc,REASON_RULE) end
+				else
+					fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+					if fc and Duel.SendtoGrave(fc,REASON_RULE)==0 then Duel.SendtoGrave(tc,REASON_RULE) end
+				end
 			end
 			Duel.MoveToField(tc,tp,tp,LOCATION_SZONE,POS_FACEUP,true)
+			if bit.band(tpe,TYPE_TRAP+TYPE_FIELD)==TYPE_TRAP+TYPE_FIELD then
+				Duel.MoveSequence(tc,5)
+			end
 			Duel.Hint(HINT_CARD,0,tc:GetCode())
 			tc:CreateEffectRelation(te)
 			if bit.band(tpe,TYPE_EQUIP+TYPE_CONTINUOUS+TYPE_FIELD)==0 then

--- a/script/c511001608.lua
+++ b/script/c511001608.lua
@@ -114,14 +114,20 @@ function c511001608.filter(c,e,tp)
 end
 function c511001608.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local ct=e:GetHandler():GetOverlayCount()
-	if chk==0 then return ct>0 and e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_EFFECT) and Duel.GetLocationCount(tp,LOCATION_MZONE)>=ct
-		and Duel.IsExistingMatchingCard(c511001608.filter,tp,LOCATION_EXTRA,0,ct,nil,e,tp) end
+	local ect=c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]
+	if chk==0 then return (not ect or ect>=ct) and ct>0 and e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_EFFECT) 
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>=ct and Duel.IsExistingMatchingCard(c511001608.filter,tp,LOCATION_EXTRA,0,ct,nil,e,tp) 
+		and (not Duel.IsPlayerAffectedByEffect(tp,59822133) or ct<2) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,ct,tp,LOCATION_EXTRA)
 end
 function c511001608.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local ct=c:GetOverlayCount()
-	if Duel.GetLocationCount(tp,LOCATION_MZONE)<ct then return end
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	if ct>ft then return end
+	if ct>1 and Duel.IsPlayerAffectedByEffect(tp,59822133) then return end
+	local ect=c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]
+	if ect~=nil and ct>ect then return end
 	local g=Duel.GetMatchingGroup(c511001608.filter,tp,LOCATION_EXTRA,0,nil,e,tp)
 	if g:GetCount()<ct then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)

--- a/script/c511001781.lua
+++ b/script/c511001781.lua
@@ -1,4 +1,4 @@
---Number C6: Chronomaly Chaos Atlandis (Anime)
+--CNo.6 先史遺産カオス・アトランタル
 function c511001781.initial_effect(c)
 	--xyz summon
 	aux.AddXyzProcedure(c,nil,7,3)
@@ -32,8 +32,10 @@ function c511001781.rumfilter(c)
 	return c:IsCode(9161357) and not c:IsPreviousLocation(LOCATION_OVERLAY)
 end
 function c511001781.rankupregcon(e,tp,eg,ep,ev,re,r,rp)
-		local rc=re:GetHandler()
-	return e:GetHandler():IsSummonType(SUMMON_TYPE_XYZ) and (rc:IsSetCard(0x95) or rc:IsCode(100000581) or rc:IsCode(111011002) or rc:IsCode(511000580) or rc:IsCode(511002068) or rc:IsCode(511002164) or rc:IsCode(93238626)) and e:GetHandler():GetMaterial():IsExists(c511001781.rumfilter,1,nil)
+	local rc=re:GetHandler()
+	return e:GetHandler():IsSummonType(SUMMON_TYPE_XYZ) and re 
+		and (rc:IsSetCard(0x95) or rc:IsCode(100000581) or rc:IsCode(111011002) or rc:IsCode(511000580) or rc:IsCode(511002068) or rc:IsCode(511002164) or rc:IsCode(93238626)) 
+		and e:GetHandler():GetMaterial():IsExists(c511001781.rumfilter,1,nil)
 end
 function c511001781.rankupregop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
@@ -85,11 +87,8 @@ function c511001781.rankupregop(e,tp,eg,ep,ev,re,r,rp)
 	--lp 1
 	local e5=Effect.CreateEffect(c)
 	e5:SetDescription(aux.Stringid(84926738,1))
-	e5:SetCategory(CATEGORY_DESTROY+CATEGORY_TOHAND)
-	e5:SetType(EFFECT_TYPE_QUICK_O)
-	e5:SetCode(EVENT_FREE_CHAIN)
+	e5:SetType(EFFECT_TYPE_IGNITION)
 	e5:SetRange(LOCATION_MZONE)
-	e5:SetCondition(c511001781.lpcon)
 	e5:SetCost(c511001781.lpcost)
 	e5:SetTarget(c511001781.lptg)
 	e5:SetOperation(c511001781.lpop)
@@ -122,7 +121,7 @@ end
 function c511001781.eqop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
+	if tc and tc:IsRelateToEffect(e) then
 		if c:IsFaceup() and c:IsRelateToEffect(e) and tc~=c then
 			if not Duel.Equip(tp,tc,c,false) then return end
 			local e1=Effect.CreateEffect(c)
@@ -154,7 +153,6 @@ function c511001781.val(e,c)
 	return c:GetEquipGroup():FilterCount(c511001781.eqtc,nil)*1000
 end
 function c511001781.discon(e,tp,eg,ep,ev,re,r,rp)
-	if not c511001781.eqcon(e,tp,eg,ep,ev,re,r,rp) then return false end
 	if e:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED) then return false end
 	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return false end
 	local tg=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
@@ -179,38 +177,25 @@ function c511001781.disop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.Destroy(eg,REASON_EFFECT)
 	end
 end
-function c511001781.lpcon(e,tp,eg,ep,ev,re,r,rp)
-	if not c511001781.eqcon(e,tp,eg,ep,ev,re,r,rp) then return false end
-	local res,teg,tep,tev,tre,tr,trp=Duel.CheckEvent(EVENT_CHAINING,true)
-	if res and tre then
-		if tre==e then return false end
-	end
-	return Duel.GetTurnPlayer()==tp and Duel.GetCurrentPhase()==PHASE_MAIN1
+function c511001781.lpcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,3,REASON_COST) and Duel.GetActivityCount(tp,ACTIVITY_ATTACK)==0 end
+	e:GetHandler():RemoveOverlayCard(tp,3,3,REASON_COST)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_CANNOT_ATTACK_ANNOUNCE)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_OATH)
+	e1:SetTargetRange(1,0)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e1,tp)
 end
 function c511001781.lptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLP(1-tp)~=1 end
-end
-function c511001781.lpcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	local c=e:GetHandler()
-	if chk==0 then return c:CheckRemoveOverlayCard(tp,3,REASON_COST) end
-	local ov=c:GetOverlayGroup()
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVEXYZ)
-	local sg=ov:Select(tp,3,3,nil)
-	Duel.SendtoGrave(sg,REASON_COST)
-	local e1=Effect.CreateEffect(e:GetHandler())
-	e1:SetType(EFFECT_TYPE_FIELD)
-	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_OATH)
-	e1:SetTargetRange(1,0)
-	e1:SetCode(EFFECT_CANNOT_BP)
-	e1:SetReset(RESET_PHASE+PHASE_END)
-	Duel.RegisterEffect(e1,tp)
 end
 function c511001781.lpop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.SetLP(1-tp,1)
 end
 function c511001781.spcon(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	return tp==Duel.GetTurnPlayer() and c:GetOverlayCount()==0
+	return tp==Duel.GetTurnPlayer() and e:GetHandler():GetOverlayCount()==0
 end
 function c511001781.spfilter(c,e,tp,mc)
 	return c:IsCode(9161357) and mc:IsCanBeXyzMaterial(c) and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_XYZ,tp,false,true)

--- a/script/c511001954.lua
+++ b/script/c511001954.lua
@@ -1,7 +1,7 @@
 --BF－孤高のシルバー・ウィンド
 function c511001954.initial_effect(c)
 	--synchro summon
-	aux.AddSynchroProcedure(c,aux.FilterBoolFunction(Card.IsSetCard,0x33),aux.NonTuner(nil),1)
+	aux.AddSynchroProcedure(c,aux.FilterBoolFunction(Card.IsSetCard,0x33),aux.NonTuner(nil),2)
 	c:EnableReviveLimit()
 	--destroy
 	local e1=Effect.CreateEffect(c)

--- a/script/c511002395.lua
+++ b/script/c511002395.lua
@@ -25,7 +25,11 @@ function c511002395.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c511002395.activate(e,tp,eg,ep,ev,re,r,rp)
 	local sg=Duel.GetMatchingGroup(c511002395.filter,tp,LOCATION_MZONE,0,nil)
-	if Duel.SendtoDeck(sg,nil,0,REASON_EFFECT)>0 then
+	local ct=Duel.SendtoDeck(sg,nil,0,REASON_EFFECT)
+	if ct>0 then
+		if Duel.IsPlayerAffectedByEffect(tp,59822133) and ct>1 then return end
+		local ect=c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]
+		if ect~=nil and ct>ect then return end
 		local spg=Group.CreateGroup()
 		local tc=sg:GetFirst()
 		while tc do

--- a/script/c511002473.lua
+++ b/script/c511002473.lua
@@ -10,6 +10,22 @@ function c511002473.initial_effect(c)
 	e1:SetTarget(c511002473.target)
 	e1:SetOperation(c511002473.activate)
 	c:RegisterEffect(e1)
+	if not c511002473.global_check then
+		c511002473.global_check=true
+		--check obsolete ruling
+		local ge1=Effect.CreateEffect(c)
+		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge1:SetCode(EVENT_DRAW)
+		ge1:SetOperation(c511002473.checkop)
+		Duel.RegisterEffect(ge1,0)
+	end
+end
+function c511002473.checkop(e,tp,eg,ep,ev,re,r,rp)
+	if bit.band(r,REASON_RULE)~=0 and Duel.GetTurnCount()==1 then
+		--obsolete
+		Duel.RegisterFlagEffect(tp,62765383,0,0,1)
+		Duel.RegisterFlagEffect(1-tp,62765383,0,0,1)
+	end
 end
 function c511002473.condition(e,tp,eg,ep,ev,re,r,rp)
 	local a=Duel.GetAttacker()
@@ -40,7 +56,21 @@ function c511002473.activate(e,tp,eg,ep,ev,re,r,rp)
 		e:SetCategory(te:GetCategory())
 		e:SetProperty(te:GetProperty())
 		Duel.ClearTargetCard()
+		if bit.band(tpe,TYPE_FIELD)~=0 then
+			local fc=Duel.GetFieldCard(1-tp,LOCATION_SZONE,5)
+			if Duel.GetFlagEffect(tp,62765383)>0 then
+				if fc then Duel.Destroy(fc,REASON_RULE) end
+				of=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+				if fc and Duel.Destroy(fc,REASON_RULE)==0 then Duel.SendtoGrave(tc,REASON_RULE) end
+			else
+				fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+				if fc and Duel.SendtoGrave(fc,REASON_RULE)==0 then Duel.SendtoGrave(tc,REASON_RULE) end
+			end
+		end
 		Duel.MoveToField(tc,tp,tp,LOCATION_SZONE,POS_FACEUP,true)
+		if bit.band(tpe,TYPE_TRAP+TYPE_FIELD)==TYPE_TRAP+TYPE_FIELD then
+			Duel.MoveSequence(tc,5)
+		end
 		Duel.Hint(HINT_CARD,0,tc:GetCode())
 		tc:CreateEffectRelation(te)
 		if bit.band(tpe,TYPE_EQUIP+TYPE_CONTINUOUS+TYPE_FIELD)==0 then

--- a/script/c511002620.lua
+++ b/script/c511002620.lua
@@ -83,11 +83,14 @@ function c511002620.synfilter(c,mg)
 	return c:IsSynchroSummonable(nil,mg) and mg:CheckWithSumEqual(Card.GetSynchroLevel,c:GetLevel(),mg:GetCount(),mg:GetCount(),c)
 end
 function c511002620.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return c511002620.chk(e,tp) end
+	local ect=c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]
+	if chk==0 then return (not ect or ect>=2) and c511002620.chk(e,tp) and not Duel.IsPlayerAffectedByEffect(tp,59822133) 
+		and (not ect or ect>=2) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,tp,LOCATION_EXTRA)
 end
 function c511002620.activate(e,tp,eg,ep,ev,re,r,rp)
-	if not c511002620.chk(e,tp) then return end
+	local ect=c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]
+	if not c511002620.chk(e,tp) or Duel.IsPlayerAffectedByEffect(tp,29724053) or (ect and ect<2) then return end
 	local chkf=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and PLAYER_NONE or tp
 	local mg1=Duel.GetMatchingGroup(c511002620.filter1,tp,LOCATION_MZONE,0,nil,e)
 	local sg1=Duel.GetMatchingGroup(c511002620.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)

--- a/script/c511002649.lua
+++ b/script/c511002649.lua
@@ -18,12 +18,15 @@ function c511002649.spfilter(c,e,tp)
 	return c:GetLevel()==10 and c:IsRace(RACE_DRAGON) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c511002649.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	local ect=c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>1 and not Duel.IsPlayerAffectedByEffect(tp,59822133) 
-		and Duel.IsExistingMatchingCard(c511002649.spfilter,tp,LOCATION_EXTRA,0,2,nil,e,tp) end
+		and Duel.IsExistingMatchingCard(c511002649.spfilter,tp,LOCATION_EXTRA,0,2,nil,e,tp) and (not ect or ect>=2) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,tp,LOCATION_EXTRA)
 end
 function c511002649.operation(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 or Duel.IsPlayerAffectedByEffect(tp,59822133) then return end
+	local ect=c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]
+	if ect~=nil and ect<2 then return end
 	local g=Duel.GetMatchingGroup(c511002649.spfilter,tp,LOCATION_EXTRA,0,nil,e,tp)
 	if g:GetCount()<2 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)

--- a/script/c511009318.lua
+++ b/script/c511009318.lua
@@ -1,4 +1,5 @@
 --Performapal Pendulum Art and Clean
+--fixed by MLD
 function c511009318.initial_effect(c)
 	--activate
 	local e1=Effect.CreateEffect(c)
@@ -7,15 +8,9 @@ function c511009318.initial_effect(c)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetCondition(c511009318.condition)
 	e1:SetCost(c511009318.cost)
-	e1:SetTarget(c511009318.tg)
-	e1:SetOperation(c511009318.op)
+	e1:SetTarget(c511009318.target)
+	e1:SetOperation(c511009318.activate)
 	c:RegisterEffect(e1)
-	--to grave
-	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
-	e2:SetCode(EVENT_TO_GRAVE)
-	e2:SetOperation(c511009318.regop)
-	c:RegisterEffect(e2)
 end
 function c511009318.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)==0
@@ -39,14 +34,33 @@ end
 function c511009318.filter(c,e,tp)
 	return c:IsSetCard(0x9f) and c:IsType(TYPE_PENDULUM) and c:IsFaceup() and c:GetLevel()==1 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
-function c511009318.tg(e,tp,eg,ep,ev,re,r,rp,chk)
+function c511009318.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0 
 		and Duel.IsExistingMatchingCard(c511009318.filter,tp,LOCATION_EXTRA,0,1,nil,e,tp) end
+	if e:IsHasType(EFFECT_TYPE_ACTIVATE) then
+		local e1=Effect.CreateEffect(c)
+		e1:SetDescription(aux.Stringid(24919805,1))
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+		e1:SetCode(EVENT_PHASE+PHASE_BATTLE)
+		e1:SetCategory(CATEGORY_DESTROY)
+		e1:SetRange(LOCATION_GRAVE)
+		e1:SetCountLimit(1)
+		e1:SetCondition(c511009318.descon)
+		e1:SetCost(c511009318.descost)
+		e1:SetTarget(c511009318.destg)
+		e1:SetOperation(c511009318.desop)
+		e1:SetReset(RESET_EVENT+0x17a0000+RESET_PHASE+PHASE_END)
+		c:RegisterEffect(e1)
+	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
-function c511009318.op(e,tp,eg,ep,ev,re,r,rp)
+function c511009318.activate(e,tp,eg,ep,ev,re,r,rp)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	if ft<=0 then return end
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then ft=1 end
+	local ect=c29724053 and Duel.IsPlayerAffectedByEffect(tp,29724053) and c29724053[tp]
+	if ect~=nil then ft=math.min(ft,ect) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,c511009318.filter,tp,LOCATION_EXTRA,0,ft,ft,nil,e,tp)
 	local c=e:GetHandler()
@@ -72,33 +86,12 @@ function c511009318.op(e,tp,eg,ep,ev,re,r,rp)
 	end
 	Duel.SpecialSummonComplete()
 end
-
-function c511009318.regop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
-	if c:GetFlagEffect(511009318)>0 then
-	
-	
-	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(24919805,1))
-	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
-	e1:SetCode(EVENT_PHASE+PHASE_BATTLE)
-	e1:SetCategory(CATEGORY_DESTROY)
-	e1:SetRange(LOCATION_GRAVE)
-	e1:SetCountLimit(1)
-	e1:SetCost(c511009318.descost)
-	e1:SetTarget(c511009318.destg)
-	e1:SetOperation(c511009318.desop)
-	e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
-	c:RegisterEffect(e1)
-	
-	end
-end
-function c511009318.descon(e)
-	local c=e:GetHandler()
-	return not c:GetFlagEffect(511009318)==0 
+function c511009318.descon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsReason(REASON_RULE)
 end
 function c511009318.cfilter(c)
-	return c:IsSetCard(0x9f) and c:IsType(TYPE_MONSTER) and c:IsAbleToDeckAsCost()
+	return c:IsSetCard(0x9f) and c:IsAbleToDeckAsCost() 
+		and Duel.IsExistingMatchingCard(Card.IsStatus,0,LOCATION_MZONE,LOCATION_MZONE,1,c,STATUS_SPSUMMON_TURN)
 end
 function c511009318.descost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c511009318.cfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
@@ -106,15 +99,12 @@ function c511009318.descost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.SelectMatchingCard(tp,c511009318.cfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
 	Duel.SendtoDeck(g,nil,2,REASON_COST)
 end
-function c511009318.desfilter(c)
-	return c:IsStatus(STATUS_SPSUMMON_TURN)
-end
 function c511009318.destg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c511009318.desfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
-	local g=Duel.GetMatchingGroup(c511009318.desfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsStatus,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,STATUS_SPSUMMON_TURN) end
+	local g=Duel.GetMatchingGroup(Card.IsStatus,tp,LOCATION_MZONE,LOCATION_MZONE,nil,STATUS_SPSUMMON_TURN)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
 end
 function c511009318.desop(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetMatchingGroup(c511009318.desfilter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+	local g=Duel.GetMatchingGroup(Card.IsStatus,tp,LOCATION_MZONE,LOCATION_MZONE,nil,STATUS_SPSUMMON_TURN)
 	Duel.Destroy(g,REASON_EFFECT)
 end

--- a/script/c511009338.lua
+++ b/script/c511009338.lua
@@ -67,7 +67,7 @@ function c511009338.activate(e,tp,eg,ep,ev,re,r,rp)
 				of=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
 				if fc and Duel.Destroy(fc,REASON_RULE)==0 then Duel.SendtoGrave(tc,REASON_RULE) end
 			else
-				Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+				fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
 				if fc and Duel.SendtoGrave(fc,REASON_RULE)==0 then Duel.SendtoGrave(tc,REASON_RULE) end
 			end
 		end

--- a/script/c511009392.lua
+++ b/script/c511009392.lua
@@ -1,8 +1,8 @@
 --D/D/D Knowledge King Tomb Conquistador
+--fixed by MLD
 function c511009392.initial_effect(c)
 	--pendulum summon
 	aux.EnablePendulumAttribute(c)
-	-- Peffect
 	--activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -18,8 +18,9 @@ function c511009392.initial_effect(c)
 	e2:SetCategory(CATEGORY_ATKCHANGE)
 	e2:SetType(EFFECT_TYPE_IGNITION)
 	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1)
 	e2:SetCost(c511009392.cost)
-	e2:SetOperation(c511009392.operation)
+	e2:SetOperation(c511009392.op)
 	c:RegisterEffect(e2)
 	--actlimit
 	local e3=Effect.CreateEffect(c)
@@ -38,13 +39,9 @@ function c511009392.initial_effect(c)
 	e4:SetOperation(c511009392.thop)
 	c:RegisterEffect(e4)
 end
--- REGEN LP
 function c511009392.damcon(e,tp,eg,ep,ev,re,r,rp)
-	if tp~=Duel.GetTurnPlayer() then return false end
-	local ex,cg,ct,cp,cv=Duel.GetOperationInfo(ev,CATEGORY_DAMAGE)
-	if ex and (cp==tp or cp==PLAYER_ALL) then return true end
-	ex,cg,ct,cp,cv=Duel.GetOperationInfo(ev,CATEGORY_RECOVER)
-	return re:IsSetCard(0xae) and ex and (cp==tp or cp==PLAYER_ALL) and Duel.IsPlayerAffectedByEffect(tp,EFFECT_REVERSE_RECOVER)
+	return aux.damcon1(e,tp,eg,ep,ev,re,r,rp) and ep==tp and re:GetHandler():IsSetCard(0xae) 
+		and Duel.GetCurrentPhase()==PHASE_STANDBY and Duel.GetTurnPlayer()==tp
 end
 function c511009392.damop(e,tp,eg,ep,ev,re,r,rp)
 	local cid=Duel.GetChainInfo(ev,CHAININFO_CHAIN_ID)
@@ -64,16 +61,13 @@ function c511009392.refcon(e,re,r,rp,rc)
 	local cid=Duel.GetChainInfo(0,CHAININFO_CHAIN_ID)
 	return cid==e:GetLabel()
 end
-
-
---ATK UP
 function c511009392.cfilter(c)
-	return c:IsSetCard(0xae) and c:IsAbleToGraveAsCost()
+	return (c:IsLocation(LOCATION_HAND) or c:IsFaceup()) and c:IsSetCard(0xae) and c:IsAbleToGraveAsCost()
 end
 function c511009392.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c511009392.cfilter,tp,LOCATION_SZONE+LOCATION_HAND,0,1,nil) end
+	if chk==0 then return Duel.IsExistingMatchingCard(c511009392.cfilter,tp,LOCATION_ONFIELD+LOCATION_HAND,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-	local g=Duel.SelectMatchingCard(tp,c511009392.cfilter,tp,LOCATION_SZONE+LOCATION_HAND,0,1,1,nil)
+	local g=Duel.SelectMatchingCard(tp,c511009392.cfilter,tp,LOCATION_ONFIELD+LOCATION_HAND,0,1,1,nil)
 	Duel.SendtoGrave(g,REASON_COST)
 end
 function c511009392.operation(e,tp,eg,ep,ev,re,r,rp)
@@ -87,7 +81,6 @@ function c511009392.operation(e,tp,eg,ep,ev,re,r,rp)
 		c:RegisterEffect(e1)
 	end
 end
-
 function c511009392.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD)

--- a/script/c511010104.lua
+++ b/script/c511010104.lua
@@ -1,7 +1,8 @@
 --No.104 仮面魔踏士シャイニング
+--fixed by MLD
 function c511010104.initial_effect(c)
 	--xyz summon
-	aux.AddXyzProcedure(c,aux.FilterBoolFunction(Card.IsAttribute,ATTRIBUTE_LIGHT),4,3)
+	aux.AddXyzProcedure(c,nil,4,3)
 	c:EnableReviveLimit()
 	--negate activate
 	local e1=Effect.CreateEffect(c)
@@ -23,6 +24,8 @@ function c511010104.initial_effect(c)
 	e2:SetType(EFFECT_TYPE_IGNITION)
 	e2:SetCountLimit(1)
 	e2:SetRange(LOCATION_MZONE)
+	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e2:SetCost(c511010104.deckcost)
 	e2:SetTarget(c511010104.decktg)
 	e2:SetOperation(c511010104.deckop)
 	c:RegisterEffect(e2)
@@ -63,6 +66,16 @@ function c511010104.operation(e,tp,eg,ep,ev,re,r,rp)
 		Duel.Damage(1-tp,800,REASON_EFFECT)
 	end
 end
+function c511010104.deckcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return c:GetAttackAnnouncedCount()==0 end
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_OATH)
+	e1:SetCode(EFFECT_CANNOT_ATTACK)
+	e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+	c:RegisterEffect(e1,true)
+end
 function c511010104.decktg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsPlayerCanDiscardDeck(1-tp,1) end
 	Duel.SetTargetPlayer(1-tp)
@@ -72,12 +85,13 @@ end
 function c511010104.deckop(e,tp,eg,ep,ev,re,r,rp)
 	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
 	Duel.DiscardDeck(p,d,REASON_EFFECT)
+	Duel.BreakEffect()
+	Duel.ShuffleDeck(p)
 end
-
 function c511010104.numchk(e,tp,eg,ep,ev,re,r,rp)
 	Duel.CreateToken(tp,2061963)
 	Duel.CreateToken(1-tp,2061963)
 end
 function c511010104.indes(e,c)
-return not c:IsSetCard(0x48)
+	return not c:IsSetCard(0x48)
 end

--- a/script/c511010192.lua
+++ b/script/c511010192.lua
@@ -1,4 +1,5 @@
---CNo.92 偽骸虚龍 Heart－eartH Chaos Dragon (Anime)
+--CNo.92 偽骸虚龍 Heart－eartH Chaos Dragon
+--fixed by MLD
 function c511010192.initial_effect(c)
 	--xyz summon
 	aux.AddXyzProcedure(c,nil,10,4)
@@ -10,33 +11,19 @@ function c511010192.initial_effect(c)
 	e1:SetCondition(c511010192.rankupregcon)
 	e1:SetOperation(c511010192.rankupregop)
 	c:RegisterEffect(e1)
-	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
-	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
-	e2:SetLabel(0)
-	c:RegisterEffect(e2)
 	--recover
 	local e3=Effect.CreateEffect(c)
 	e3:SetDescription(aux.Stringid(511010192,0))
+	e3:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 	e3:SetCategory(CATEGORY_RECOVER)
 	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
 	e3:SetCode(EVENT_PHASE+PHASE_BATTLE)
 	e3:SetRange(LOCATION_MZONE)
-	e3:SetLabelObject(e2)
 	e3:SetCountLimit(1)
+	e3:SetCondition(c511010192.reccon)
 	e3:SetTarget(c511010192.rectg)
 	e3:SetOperation(c511010192.recop)
 	c:RegisterEffect(e3)
-	--reset
-	local e5=Effect.CreateEffect(c)
-	e5:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-	e5:SetCode(EVENT_ADJUST)
-	e5:SetCountLimit(1)
-	e5:SetRange(LOCATION_MZONE)
-	e5:SetOperation(c511010192.reset)
-	e5:SetLabelObject(e2)
-	c:RegisterEffect(e5)
 	--battle indestructable
 	local e6=Effect.CreateEffect(c)
 	e6:SetType(EFFECT_TYPE_SINGLE)
@@ -45,6 +32,8 @@ function c511010192.initial_effect(c)
 	c:RegisterEffect(e6)
 	if not c511010192.global_check then
 		c511010192.global_check=true
+		c511010192[0]=0
+		c511010192[1]=0
 		local ge2=Effect.CreateEffect(c)
 		ge2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 		ge2:SetCode(EVENT_ADJUST)
@@ -52,24 +41,40 @@ function c511010192.initial_effect(c)
 		ge2:SetProperty(EFFECT_FLAG_NO_TURN_RESET)
 		ge2:SetOperation(c511010192.numchk)
 		Duel.RegisterEffect(ge2,0)
-			--check
-			local ge3=Effect.CreateEffect(c)
-			ge3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-			ge3:SetProperty(EFFECT_FLAG_DAMAGE_STEP)
-			ge3:SetCode(EVENT_DAMAGE)
-			ge3:SetCondition(c511010192.checkcon)
-			ge3:SetOperation(c511010192.checkop)
-			ge3:SetLabelObject(e2)
-			Duel.RegisterEffect(ge3,0)
+		local ge2=Effect.CreateEffect(c)
+		ge2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge2:SetCode(EVENT_BATTLE_DAMAGE)
+		ge2:SetOperation(c511010192.checkop)
+		Duel.RegisterEffect(ge2,0)
+		local ge3=Effect.CreateEffect(c)
+		ge3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge3:SetCode(EVENT_ADJUST)
+		ge3:SetCountLimit(1)
+		ge3:SetOperation(c511010192.clear)
+		Duel.RegisterEffect(ge3,0)
 	end
 end
 c511010192.xyz_number=92
+function c511010192.checkop(e,tp,eg,ep,ev,re,r,rp)
+	if ep==tp then
+		c511010192[tp]=c511010192[tp]+ev
+	end
+	if ep==1-tp then
+		c511010192[1-tp]=c511010192[1-tp]+ev
+	end
+end
+function c511010192.clear(e,tp,eg,ep,ev,re,r,rp)
+	c511010192[0]=0
+	c511010192[1]=0
+end
 function c511010192.rumfilter(c)
 	return c:IsCode(97403510) and not c:IsPreviousLocation(LOCATION_OVERLAY)
 end
 function c511010192.rankupregcon(e,tp,eg,ep,ev,re,r,rp)
-		local rc=re:GetHandler()
-	return e:GetHandler():IsSummonType(SUMMON_TYPE_XYZ) and (rc:IsSetCard(0x95) or rc:IsCode(100000581) or rc:IsCode(111011002) or rc:IsCode(511000580) or rc:IsCode(511002068) or rc:IsCode(511002164) or rc:IsCode(93238626)) and e:GetHandler():GetMaterial():IsExists(c511010192.rumfilter,1,nil)
+	local rc=re:GetHandler()
+	return e:GetHandler():IsSummonType(SUMMON_TYPE_XYZ) and re 
+		and (rc:IsSetCard(0x95) or rc:IsCode(100000581) or rc:IsCode(111011002) or rc:IsCode(511000580) or rc:IsCode(511002068) or rc:IsCode(511002164) or rc:IsCode(93238626)) 
+		and e:GetHandler():GetMaterial():IsExists(c511010192.rumfilter,1,nil)
 end
 function c511010192.rankupregop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
@@ -86,29 +91,26 @@ function c511010192.rankupregop(e,tp,eg,ep,ev,re,r,rp)
 	e4:SetReset(RESET_EVENT+0x1fe0000)
 	c:RegisterEffect(e4)
 end
-function c511010192.checkcon(e,tp,eg,ep,ev,re,r,rp)
-	return ep~=tp and eg:GetFirst():IsControler(tp)
-end
-function c511010192.checkop(e,tp,eg,ep,ev,re,r,rp)
-	local val=e:GetLabelObject():GetLabel()+ev
-		e:GetLabelObject():SetLabel(val)
+function c511010192.reccon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()==tp
 end
 function c511010192.rectg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
+	if chk==0 then return c511010192[1-tp]>0 end
 	Duel.SetTargetPlayer(tp)
-	Duel.SetOperationInfo(0,CATEGORY_RECOVER,nil,0,tp,e:GetLabelObject():GetLabel())
+	Duel.SetOperationInfo(0,CATEGORY_RECOVER,nil,0,tp,c511010192[1-tp])
 end
 function c511010192.recop(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end
 	local p=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER)
-	Duel.Recover(p,e:GetLabelObject():GetLabel(),REASON_EFFECT)
+	Duel.Recover(p,c511010192[1-tp],REASON_EFFECT)
 end
 function c511010192.discost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end
 	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
 end
 function c511010192.distg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(aux.disfilter1,tp,0,LOCATION_ONFIELD,1,nil) end
+	if chk==0 then return Duel.IsExistingMatchingCard(aux.disfilter1,tp,0,LOCATION_ONFIELD,1,nil) 
+		or Duel.IsExistingMatchingCard(Card.IsFacedown,tp,LOCATION_SZONE,LOCATION_SZONE,1,nil) end
 end
 function c511010192.disop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
@@ -134,14 +136,21 @@ function c511010192.disop(e,tp,eg,ep,ev,re,r,rp)
 		end
 		tc=g:GetNext()
 	end
+	local g2=Duel.GetMatchingGroup(Card.IsFacedown,tp,LOCATION_SZONE,LOCATION_SZONE,nil)
+	tc=g2:GetFirst()
+	while tc do
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_CANNOT_TRIGGER)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		tc:RegisterEffect(e1)
+		tc=g2:GetNext()
+	end
 end
 function c511010192.numchk(e,tp,eg,ep,ev,re,r,rp)
 	Duel.CreateToken(tp,47017574)
 	Duel.CreateToken(1-tp,47017574)
 end
 function c511010192.indes(e,c)
-return not c:IsSetCard(0x48)
-end
-function c511010192.reset(e,tp,eg,ep,ev,re,r,rp,chk)
-	e:GetLabelObject():SetLabel(0)
+	return not c:IsSetCard(0x48)
 end


### PR DESCRIPTION
Anime Cards working with Summon Gate
Number C106 Rank Up Check
Number C6 obsolete filter removal
Blackwing Silverwind Anime required Material change (db update not yet included)
Binding Swords of Impact fix and cleanup
D/D/D Knowledge King Tomb Conquistador OPT gain ATK check and cleanup
Number 104 Required Material and cost fix
Number C92 doesn't check Set Cards