### PR TITLE
Added fix for old DEFENCE constants

### DIFF
--- a/script/utility.lua
+++ b/script/utility.lua
@@ -1,5 +1,7 @@
 Auxiliary={}
 aux=Auxiliary
+POS_FACEUP_DEFENCE=POS_FACEUP_DEFENSE
+POS_FACEDOWN_DEFENCE=POS_FACEDOWN_DEFENSE
 
 function Auxiliary.Stringid(code,id)
 	return code*16+id


### PR DESCRIPTION
These two lines of code come directly from Fluoro's utilities, and make it so that the old POS_FACEUP_DEFENCE and POS_FACEDOWN_DEFENCE are treated as respectively POS_FACEUP_DEFENSE and POS_FACEDOWN_DEFENSE. This should hopefully resolve most of the issues with the puzzle Duels.