### PR TITLE
Anime Card Fixes

### DIFF
--- a/script/c511001489.lua
+++ b/script/c511001489.lua
@@ -1,4 +1,4 @@
---The Legendary Fisherman III
+--伝説のフィッシャーマン三世
 function c511001489.initial_effect(c)
 	--special summon
 	local e1=Effect.CreateEffect(c)
@@ -31,12 +31,15 @@ function c511001489.initial_effect(c)
 	--indes
 	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_SINGLE)
-	e4:SetCode(EFFECT_INDESTRUCTABLE_EFFECT)
+	e4:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
 	e4:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
 	e4:SetRange(LOCATION_MZONE)
 	e4:SetCondition(c511001489.econ)
 	e4:SetValue(1)
 	c:RegisterEffect(e4)
+	local e5=e4:Clone()
+	e5:SetCode(EFFECT_INDESTRUCTABLE_EFFECT)
+	c:RegisterEffect(e5)
 end
 function c511001489.hspcon(e,c)
 	if c==nil then return true end

--- a/script/c511001654.lua
+++ b/script/c511001654.lua
@@ -5,40 +5,46 @@ function c511001654.initial_effect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
-	e1:SetHintTiming(0,TIMING_BATTLE_START+TIMING_BATTLE_END)
-	e1:SetCondition(c511001654.sccon)
 	e1:SetTarget(c511001654.sctg)
 	e1:SetOperation(c511001654.scop)
 	c:RegisterEffect(e1)
+	if not c511001654.global_check then
+		c511001654.global_check=true
+		local ge1=Effect.CreateEffect(c)
+		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge1:SetCode(EVENT_SPSUMMON_SUCCESS)
+		ge1:SetOperation(c511001654.checkop)
+		Duel.RegisterEffect(ge1,0)
+	end
 end
-function c511001654.sccon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<=PHASE_BATTLE
+function c511001654.checkop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<=PHASE_BATTLE then
+		local tc=eg:GetFirst()
+		while tc do
+			tc:RegisterFlagEffect(511001654,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,0)
+			tc=eg:GetNext()
+		end
+	end
 end
-function c511001654.spfilter(c,e,tp)
-	return c:IsType(TYPE_SYNCHRO) and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_SYNCHRO,tp,true,false) 
-		and Duel.IsExistingMatchingCard(c511001654.filter,tp,LOCATION_MZONE,0,1,nil,c,c:GetLevel())
+function c511001654.spfilter(c,tp)
+	return Duel.IsExistingMatchingCard(c511001654.filter,tp,LOCATION_MZONE,0,1,nil,c)
 end
-function c511001654.filter(c,sync,lv)
-	return c:IsFaceup() and c:GetSynchroLevel(sync)==lv and c:IsType(TYPE_TUNER)
-		and c:IsCanBeSynchroMaterial(sync)
+function c511001654.filter(c,sync)
+	return c:GetFlagEffect(511001654)>0 and c:IsType(TYPE_TUNER) and sync:IsSynchroSummonable(c)
 end
 function c511001654.sctg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1 
-		and Duel.IsExistingMatchingCard(c511001654.spfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp) end
+	if chk==0 then return Duel.IsExistingMatchingCard(c511001654.spfilter,tp,LOCATION_EXTRA,0,1,nil,tp) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function c511001654.scop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=-1 then return end
-	local g=Duel.GetMatchingGroup(c511001654.spfilter,tp,LOCATION_EXTRA,0,nil,e,tp)
+	local g=Duel.GetMatchingGroup(c511001654.spfilter,tp,LOCATION_EXTRA,0,nil,tp)
 	if g:GetCount()>0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-		local sc=g:Select(tp,1,1,nil):GetFirst()
+		local sg=g:Select(tp,1,1,nil)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SMATERIAL)
-		local mg=Duel.SelectMatchingCard(tp,c511001654.filter,tp,LOCATION_MZONE,0,1,1,nil,sc,sc:GetLevel())
-		sc:SetMaterial(mg)
-		Duel.SendtoGrave(mg,REASON_MATERIAL+REASON_SYNCHRO)
-		Duel.BreakEffect()
-		Duel.SpecialSummon(sc,SUMMON_TYPE_SYNCHRO,tp,tp,true,false,POS_FACEUP)
-		sc:CompleteProcedure()
+		local tg=Duel.SelectMatchingCard(tp,c511001654.filter,tp,LOCATION_MZONE,0,1,1,nil,sg:GetFirst())
+		Duel.HintSelection(tg)
+		Duel.SynchroSummon(tp,sg:GetFirst(),tg:GetFirst())
 	end
 end


### PR DESCRIPTION
The Legendary Fisherman III Anime, allow cannot be destroyed by battle (database fix not yet included)
Battle Tuning effect update (database fix not yet included)